### PR TITLE
Implement checks for input layers in plugin tools

### DIFF
--- a/pzp/calculation.py
+++ b/pzp/calculation.py
@@ -173,17 +173,24 @@ def calculate_propagation(process_type, layer_propagation, layer_breaking, group
 class CalculationDialog:
     def __init__(self, iface, group, parent=None):
         self.group = group
+        self.tool_name = "Calcolo zone di pericolo"
 
-    def exec_(self):
+    def exec_(self, force=False):
         process_type, layer_intensity = guess_params(self.group)
-        self.do_exec(process_type, layer_intensity)
+
+        check_ok = False
+        if not force:
+            check_ok = utils.check_inputs(self.tool_name, layer_intensity, self.exec_)
+
+        if force or check_ok:
+            self.do_exec(process_type, layer_intensity)
 
     def do_exec(self, process_type, layer_intensity):
         try:
             layer_pericolo = calculate(process_type, layer_intensity)
         except QgsProcessingException as processingException:
             utils.push_error_report(
-                "Calcolo zone di pericolo",
+                self.tool_name,
                 "Process: {}".format(domains.PROCESS_TYPES.get(process_type, "Unknown process!")),
                 f"Description: \n{processingException}" if "traceback" not in str(processingException).lower() else "",
                 traceback.format_exc(),

--- a/pzp/calculation.py
+++ b/pzp/calculation.py
@@ -209,6 +209,9 @@ class CalculationTool:
     def run(self, force=False):
         process_type, layer_intensity = self._guess_params()
 
+        if process_type is None or layer_intensity is None:
+            return
+
         check_ok = False
         if not force:
             check_ok = utils.check_inputs(self._tool_name, layer_intensity, self.run)

--- a/pzp/calculation.py
+++ b/pzp/calculation.py
@@ -251,6 +251,7 @@ class CalculationTool:
             if pzp_layer == "intensity":
                 layer_intensity = layer_node.layer()
                 process_type = int(QgsExpressionContextUtils.layerScope(layer_intensity).variable("pzp_process"))
+                break
 
         if not layer_intensity:
             utils.push_error("Layer con le intensità non trovato", 3)

--- a/pzp/calculation.py
+++ b/pzp/calculation.py
@@ -57,7 +57,7 @@ class PropagationTool:
 
         check_ok = False
         if not force:
-            check_ok = utils.check_inputs(self._tool_name, layer_propagation, self.run)
+            check_ok = utils.check_inputs(self._tool_name, layer_breaking, self.run)
 
         if force or check_ok:
             self.run_with_parameters(process_type, layer_propagation, layer_breaking)
@@ -80,6 +80,8 @@ class PropagationTool:
 
         new_layer = self._load_layer_to_project(process_type, gpkg_path, layer_name)
         self._post_layer_configuration(process_type, new_layer)
+
+        utils.push_info(f"The tool '{self._tool_name}' has finished successfully!", 5)
 
         return new_layer
 
@@ -237,6 +239,8 @@ class CalculationTool:
 
         new_layer = self._load_layer_to_project(process_type, gpkg_path, layer_name)
         self._post_layer_configuration(process_type, new_layer)
+
+        utils.push_info(f"The tool '{self._tool_name}' has finished successfully!", 5)
 
         return new_layer
 

--- a/pzp/no_impact.py
+++ b/pzp/no_impact.py
@@ -22,17 +22,29 @@ class ToolNessunImpatto:
         for layer_node in layer_nodes:
             if layer_node.name() == "Intensità completa":
                 layer_intensity = layer_node.layer()
-                process_type = int(QgsExpressionContextUtils.layerScope(layer_intensity).variable("pzp_process"))
+                var_process = QgsExpressionContextUtils.layerScope(layer_intensity).variable("pzp_process")
+                process_type = int(var_process) if var_process else None
             elif layer_node.name() == "Area di studio":
                 layer_area = layer_node.layer()
 
-        return process_type, layer_intensity, layer_area
+        if not layer_intensity:
+            utils.push_error("Layer con le intensità non trovato", 3)
+            return (False,)
+        if not layer_area:
+            utils.push_error("Layer con le area di studio non trovato", 3)
+            return (False,)
+        if not process_type:
+            utils.push_error("Impossibile determinare il tipo di processo", 3)
+            return (False,)
+
+        return True, process_type, layer_intensity, layer_area
 
     def run(self, force=False):
-        process_type, layer_intensity, layer_area = self._guess_params()
-
-        if process_type is None or layer_intensity is None or layer_area is None:
+        result = self._guess_params()
+        if not result[0]:
             return
+
+        ok, process_type, layer_intensity, layer_area = result
 
         check_ok = False
         if not force:

--- a/pzp/no_impact.py
+++ b/pzp/no_impact.py
@@ -1,53 +1,83 @@
+import traceback
+
 from qgis import processing
-from qgis.core import QgsExpressionContextUtils, edit
+from qgis.core import QgsExpressionContextUtils, QgsProcessingException, edit
+
+from pzp.processing import domains
+from pzp.utils import utils
 
 
-def guess_params(group):
-    # process and layers
-    layer_nodes = group.findLayers()
-    layer_intensity = None
-    layer_area = None
-    process_type = None
+class ToolNessunImpatto:
+    def __init__(self, group):
+        self._group = group
+        self._tool_name = "Aggiungi zone nessun impatto"
 
-    for layer_node in layer_nodes:
-        if layer_node.name() == "Intensità completa":
-            layer_intensity = layer_node.layer()
-            process_type = int(
-                QgsExpressionContextUtils.layerScope(layer_intensity).variable(
-                    "pzp_process"
-                )
+    def _guess_params(self):
+        # process and layers
+        layer_nodes = self._group.findLayers()
+        layer_intensity = None
+        layer_area = None
+        process_type = None
+
+        for layer_node in layer_nodes:
+            if layer_node.name() == "Intensità completa":
+                layer_intensity = layer_node.layer()
+                process_type = int(QgsExpressionContextUtils.layerScope(layer_intensity).variable("pzp_process"))
+            elif layer_node.name() == "Area di studio":
+                layer_area = layer_node.layer()
+
+        return process_type, layer_intensity, layer_area
+
+    def run(self, force=False):
+        process_type, layer_intensity, layer_area = self._guess_params()
+
+        check_ok = False
+        if not force:
+            check_ok = utils.check_inputs(self._tool_name, layer_intensity, self.run)
+
+        if force or check_ok:
+            self.run_with_params(process_type, layer_intensity, layer_area)
+
+    def run_with_params(self, process_type, layer_intensity, layer_area):
+        try:
+            self._calculate(process_type, layer_intensity, layer_area)
+        except (QgsProcessingException, Exception) as exc:
+            utils.push_error_report(
+                self._tool_name,
+                "Process: {}".format(domains.PROCESS_TYPES.get(process_type, "Unknown process!")),
+                f"Description: \n{exc}" if "traceback" not in str(exc).lower() else "",
+                traceback.format_exc(),
             )
-        elif layer_node.name() == "Area di studio":
-            layer_area = layer_node.layer()
+            return False
 
-    return process_type, layer_intensity, layer_area
+        utils.push_info(f"The tool '{self._tool_name}' has run successfully!", 5)
+        return True
 
+    def _calculate(self, process_type, layer_intensity, layer_area):
+        result_01 = processing.run(
+            "pzp_utils:no_impact",
+            {
+                "AREA_LAYER": layer_area.id(),
+                "AREA_PROCESS_SOURCE_FIELD": "fonte_proc",
+                "INTENSITY_PROCESS_SOURCE_FIELD": "fonte_proc",
+                "INTENSITY_LAYER": layer_intensity.id(),
+                "PERIOD_FIELD": "periodo_ritorno",
+                "INTENSITY_FIELD": "classe_intensita",
+                "OUTPUT": "TEMPORARY_OUTPUT",
+            },
+        )
 
-def calculate(process_type, layer_intensity, layer_area):
-    result = processing.run(
-        "pzp_utils:no_impact",
-        {
-            "AREA_LAYER": layer_area.id(),
-            "AREA_PROCESS_SOURCE_FIELD": "fonte_proc",
-            "INTENSITY_PROCESS_SOURCE_FIELD": "fonte_proc",
-            "INTENSITY_LAYER": layer_intensity.id(),
-            "PERIOD_FIELD": "periodo_ritorno",
-            "INTENSITY_FIELD": "classe_intensita",
-            "OUTPUT": "TEMPORARY_OUTPUT",
-        },
-    )
+        result = processing.run(
+            "pzp_utils:fix_geometries",
+            {
+                "INPUT": result_01["OUTPUT"],
+                "OUTPUT": "TEMPORARY_OUTPUT",
+            },
+        )
 
-    result = processing.run(
-        "pzp_utils:fix_geometries",
-        {
-            "INPUT": result["OUTPUT"],
-            "OUTPUT": "TEMPORARY_OUTPUT",
-        },
-    )
+        result_layer = result["OUTPUT"]
 
-    result_layer = result["OUTPUT"]
-
-    with edit(layer_intensity):
-        for feature in result_layer.getFeatures():
-            feature["fid"] = None
-            layer_intensity.addFeature(feature)
+        with edit(layer_intensity):
+            for feature in result_layer.getFeatures():
+                feature["fid"] = None
+                layer_intensity.addFeature(feature)

--- a/pzp/no_impact.py
+++ b/pzp/no_impact.py
@@ -65,7 +65,7 @@ class ToolNessunImpatto:
             )
             return False
 
-        utils.push_info(f"The tool '{self._tool_name}' has run successfully!", 5)
+        utils.push_info(f"The tool '{self._tool_name}' has finished successfully!", 5)
         return True
 
     def _calculate(self, process_type, layer_intensity, layer_area):

--- a/pzp/no_impact.py
+++ b/pzp/no_impact.py
@@ -31,6 +31,9 @@ class ToolNessunImpatto:
     def run(self, force=False):
         process_type, layer_intensity, layer_area = self._guess_params()
 
+        if process_type is None or layer_intensity is None or layer_area is None:
+            return
+
         check_ok = False
         if not force:
             check_ok = utils.check_inputs(self._tool_name, layer_intensity, self.run)

--- a/pzp/pzp.py
+++ b/pzp/pzp.py
@@ -15,7 +15,7 @@ from qgis.PyQt.QtWidgets import QAction, QMenu, QMessageBox, QToolButton
 
 from pzp import a_b
 from pzp.add_process import AddProcessDialog
-from pzp.calculation import CalculationDialog, PropagationDialog
+from pzp.calculation import CalculationTool, PropagationDialog
 from pzp.check_dock import CheckResultsDock
 from pzp.no_impact import ToolNessunImpatto
 from pzp.processing.provider import Provider
@@ -296,9 +296,9 @@ class PZP(QObject):
         current_node = self.iface.layerTreeView().currentNode()
         if isinstance(current_node, QgsLayerTreeGroup):
             # TODO: Check we have all the layers in the group
-            dlg = CalculationDialog(self.iface, current_node)
+            tool = CalculationTool(self.iface, current_node)
             with OverrideCursor(Qt.WaitCursor):
-                dlg.exec_()
+                tool.run()
         else:
             utils.push_error("Selezionare il gruppo che contiene il processo", 3)
 

--- a/pzp/pzp.py
+++ b/pzp/pzp.py
@@ -15,7 +15,7 @@ from qgis.PyQt.QtWidgets import QAction, QMenu, QMessageBox, QToolButton
 
 from pzp import a_b
 from pzp.add_process import AddProcessDialog
-from pzp.calculation import CalculationTool, PropagationDialog
+from pzp.calculation import CalculationTool, PropagationTool
 from pzp.check_dock import CheckResultsDock
 from pzp.no_impact import ToolNessunImpatto
 from pzp.processing.provider import Provider
@@ -285,9 +285,9 @@ class PZP(QObject):
         current_node = self.iface.layerTreeView().currentNode()
         if isinstance(current_node, QgsLayerTreeGroup):
             # TODO: Check we have all the layers in the group
-            dlg = PropagationDialog(self.iface, current_node)
+            tool = PropagationTool(self.iface, current_node)
             with OverrideCursor(Qt.WaitCursor):
-                dlg.exec_()
+                tool.run()
         else:
             utils.push_error("Selezionare il gruppo che contiene il processo", 3)
 

--- a/pzp/pzp.py
+++ b/pzp/pzp.py
@@ -13,10 +13,11 @@ from qgis.core import (
 from qgis.PyQt.QtCore import QObject, Qt
 from qgis.PyQt.QtWidgets import QAction, QMenu, QMessageBox, QToolButton
 
-from pzp import a_b, no_impact
+from pzp import a_b
 from pzp.add_process import AddProcessDialog
 from pzp.calculation import CalculationDialog, PropagationDialog
 from pzp.check_dock import CheckResultsDock
+from pzp.no_impact import ToolNessunImpatto
 from pzp.processing.provider import Provider
 from pzp.ui.resources import *  # noqa
 from pzp.utils import utils
@@ -306,7 +307,9 @@ class PZP(QObject):
         current_node = self.iface.layerTreeView().currentNode()
         if isinstance(current_node, QgsLayerTreeGroup):
             # TODO: Check we have all the layers in the group
-            no_impact.calculate(*no_impact.guess_params(current_node))
+            tool = ToolNessunImpatto(current_node)
+            with OverrideCursor(Qt.WaitCursor):
+                tool.run()
         else:
             utils.push_error("Selezionare il gruppo che contiene il processo", 3)
 

--- a/pzp/pzp.py
+++ b/pzp/pzp.py
@@ -284,7 +284,6 @@ class PZP(QObject):
         # Get selected group
         current_node = self.iface.layerTreeView().currentNode()
         if isinstance(current_node, QgsLayerTreeGroup):
-            # TODO: Check we have all the layers in the group
             tool = PropagationTool(self.iface, current_node)
             with OverrideCursor(Qt.WaitCursor):
                 tool.run()
@@ -295,7 +294,6 @@ class PZP(QObject):
         # Get selected group
         current_node = self.iface.layerTreeView().currentNode()
         if isinstance(current_node, QgsLayerTreeGroup):
-            # TODO: Check we have all the layers in the group
             tool = CalculationTool(self.iface, current_node)
             with OverrideCursor(Qt.WaitCursor):
                 tool.run()
@@ -306,7 +304,6 @@ class PZP(QObject):
         # Get selected group
         current_node = self.iface.layerTreeView().currentNode()
         if isinstance(current_node, QgsLayerTreeGroup):
-            # TODO: Check we have all the layers in the group
             tool = ToolNessunImpatto(current_node)
             with OverrideCursor(Qt.WaitCursor):
                 tool.run()

--- a/pzp/qml/point_error.qml
+++ b/pzp/qml/point_error.qml
@@ -1,0 +1,120 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis labelsEnabled="0" simplifyDrawingTol="1" simplifyDrawingHints="1" simplifyLocal="1" simplifyAlgorithm="0" readOnly="0" hasScaleBasedVisibilityFlag="0" maxScale="0" simplifyMaxScale="1" minScale="1e+08" version="3.1.0-Master">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
+    <symbols>
+      <symbol alpha="1" name="0" clip_to_extent="1" type="marker">
+        <layer pass="0" enabled="1" class="SimpleMarker" locked="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="255,0,0,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="2"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer pass="0" enabled="1" class="SimpleMarker" locked="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="255,0,0,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="255,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.2"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="area"/>
+          <prop k="size" v="3.4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <effect enabled="1" type="effectStack">
+            <effect type="dropShadow">
+              <prop k="blend_mode" v="0"/>
+              <prop k="blur_level" v="10"/>
+              <prop k="color" v="0,0,0,255"/>
+              <prop k="draw_mode" v="2"/>
+              <prop k="enabled" v="1"/>
+              <prop k="offset_angle" v="135"/>
+              <prop k="offset_distance" v="2"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="opacity" v="1"/>
+            </effect>
+            <effect type="drawSource">
+              <prop k="blend_mode" v="0"/>
+              <prop k="draw_mode" v="2"/>
+              <prop k="enabled" v="1"/>
+              <prop k="opacity" v="1"/>
+            </effect>
+          </effect>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer pass="0" enabled="1" class="SimpleMarker" locked="0">
+          <prop k="angle" v="34"/>
+          <prop k="color" v="255,0,0,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="255,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.2"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="area"/>
+          <prop k="size" v="2.4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <effect enabled="1" type="effectStack">
+            <effect type="drawSource">
+              <prop k="blend_mode" v="0"/>
+              <prop k="draw_mode" v="2"/>
+              <prop k="enabled" v="1"/>
+              <prop k="opacity" v="1"/>
+            </effect>
+          </effect>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" value="" type="QString"/>
+              <Option name="properties"/>
+              <Option name="type" value="collection" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+</qgis>

--- a/pzp/utils/utils.py
+++ b/pzp/utils/utils.py
@@ -83,7 +83,7 @@ def _push_input_error_report(
     tool_name: str, input_layer_name: str, error_count: int, error_output: QgsVectorLayer, callback
 ):
     widget = iface.messageBar().createMessage(
-        tool_name, f"{error_count} geometry errors found in the layer '{input_layer_name}'!"
+        tool_name, f"{error_count} errori trovati nelle geometrie del layer '{input_layer_name}'!"
     )
 
     def _see_geometry_errors(error_layer: QgsVectorLayer, tool_name: str, input_name: str):
@@ -101,7 +101,7 @@ def _push_input_error_report(
         iface.messageBar().pushMessage(tool_name, f"Showing errors in input layer '{input_name}'", Qgis.Info, 0)
 
     button = QPushButton(widget)
-    button.setText("Inspect the errors...")
+    button.setText("Ispeziona gli errori...")
     button.pressed.connect(partial(_see_geometry_errors, error_output, tool_name, input_layer_name))
     widget.layout().addWidget(button)
 
@@ -115,7 +115,7 @@ def _push_input_error_report(
             callback(True)  # force=True
 
     button = QPushButton(widget)
-    button.setText("Ignore and continue...")
+    button.setText("Ignora e continua...")
     button.pressed.connect(partial(_run_with_errors, callback, tool_name, input_layer_name, error_count))
     widget.layout().addWidget(button)
 

--- a/pzp/utils/utils.py
+++ b/pzp/utils/utils.py
@@ -24,16 +24,19 @@ from qgis.utils import iface
 from pzp.utils.override_cursor import OverrideCursor
 
 
-def push_info(message, showMore=""):
-    _get_iface().messageBar().pushInfo("pzp", message, showMore)
+def push_info(message, time=0, showMore=""):
+    args = [message, showMore, Qgis.Info, time] if showMore else [message, Qgis.Info, time]
+    _get_iface().messageBar().pushMessage("pzp", *args)
 
 
 def push_warning(message, time=0, showMore=""):
-    _get_iface().messageBar().pushMessage("pzp", message, showMore, Qgis.Warning, time)
+    args = [message, showMore, Qgis.Warning, time] if showMore else [message, Qgis.Warning, time]
+    _get_iface().messageBar().pushMessage("pzp", *args)
 
 
 def push_error(message, time=0, showMore=""):
-    _get_iface().messageBar().pushMessage("pzp", message, showMore, Qgis.Critical, time)
+    args = [message, showMore, Qgis.Critical, time] if showMore else [message, Qgis.Critical, time]
+    _get_iface().messageBar().pushMessage("pzp", *args)
 
 
 def push_error_report(title, subtitle="", description="", traceback=""):
@@ -98,7 +101,7 @@ def _push_input_error_report(
         iface.messageBar().pushMessage(tool_name, f"Showing errors in input layer '{input_name}'", Qgis.Info, 0)
 
     button = QPushButton(widget)
-    button.setText("See more...")
+    button.setText("Inspect the errors...")
     button.pressed.connect(partial(_see_geometry_errors, error_output, tool_name, input_layer_name))
     widget.layout().addWidget(button)
 
@@ -112,7 +115,7 @@ def _push_input_error_report(
             callback(True)  # force=True
 
     button = QPushButton(widget)
-    button.setText("Run with geometry errors...")
+    button.setText("Ignore and continue...")
     button.pressed.connect(partial(_run_with_errors, callback, tool_name, input_layer_name, error_count))
     widget.layout().addWidget(button)
 

--- a/pzp/utils/utils.py
+++ b/pzp/utils/utils.py
@@ -83,7 +83,7 @@ def _push_input_error_report(
     tool_name: str, input_layer_name: str, error_count: int, error_output: QgsVectorLayer, callback
 ):
     widget = iface.messageBar().createMessage(
-        tool_name, f"{error_count} geometry errors in the layer '{input_layer_name}' found!"
+        tool_name, f"{error_count} geometry errors found in the layer '{input_layer_name}'!"
     )
 
     def _see_geometry_errors(error_layer: QgsVectorLayer, tool_name: str, input_name: str):

--- a/tests/test_flusso_detrito.py
+++ b/tests/test_flusso_detrito.py
@@ -67,7 +67,7 @@ def test_flusso_detrito(plugin_instance, flusso_detrito_layer, flusso_detrito_ex
     QgsProject.instance().addMapLayer(flusso_detrito_layer)
 
     dlg = CalculationTool(get_iface(), None)
-    pericolo_layer = dlg.run_witn_parameters(process_type, flusso_detrito_layer)
+    pericolo_layer = dlg.run_with_parameters(process_type, flusso_detrito_layer)
 
     assert isinstance(pericolo_layer, QgsMapLayer)
     assert pericolo_layer.featureCount() == 101

--- a/tests/test_flusso_detrito.py
+++ b/tests/test_flusso_detrito.py
@@ -3,7 +3,7 @@ from qgis.core import QgsExpressionContextUtils, QgsMapLayer, QgsProject, QgsVec
 from qgis.testing import start_app
 from qgis.testing.mocked import get_iface
 
-from pzp.calculation import CalculationDialog
+from pzp.calculation import CalculationTool
 from tests.utils import get_copy_path, get_data_path
 
 start_app()
@@ -66,8 +66,8 @@ def test_flusso_detrito(plugin_instance, flusso_detrito_layer, flusso_detrito_ex
     # Add layer to project so that Processing can find it and use it
     QgsProject.instance().addMapLayer(flusso_detrito_layer)
 
-    dlg = CalculationDialog(get_iface(), None)
-    pericolo_layer = dlg.do_exec(process_type, flusso_detrito_layer)
+    dlg = CalculationTool(get_iface(), None)
+    pericolo_layer = dlg.run_witn_parameters(process_type, flusso_detrito_layer)
 
     assert isinstance(pericolo_layer, QgsMapLayer)
     assert pericolo_layer.featureCount() == 101


### PR DESCRIPTION
 + [x] Implement checks for input layers.
 + [x] Implement basic GUI to inform users about errors on inputs.  
    ![image](https://github.com/user-attachments/assets/c5951ae6-3510-4b53-9614-e4e0cfae5f05)
 + [x] Allow users to choose whether to inspect the errors found or to continue running the tool (even with errors).
 + [x] Inspect the errors by adding a point error layer with proper error symbology. Show attribute table with the error details.

The aforementioned features are expected to be implemented for:

 + [x] Aggiungi zone nessun impatto (layer `Intensità completa`)
 + [x] Calcolo propagazione (layer `breaking`)
 + [x] Calcolo zone di pericolo (layer `intensity`)

-------
_Note: Currently checking a single input layer per tool. Should we allow multiple layer checks?_
