### PR TITLE
Input error detection enhancements

### DIFF
--- a/pzp/utils/utils.py
+++ b/pzp/utils/utils.py
@@ -89,9 +89,13 @@ def _push_input_error_report(
     def _see_geometry_errors(error_layer: QgsVectorLayer, tool_name: str, input_name: str):
         # Style errors
         set_qml_style(error_layer, "point_error")
+        error_layer.setName("Errori Geometrici")
 
-        # Add layer to ToC
-        QgsProject.instance().addMapLayer(error_layer)
+        # Add layer to ToC, in its own group
+        QgsProject.instance().addMapLayer(error_layer, False)
+        group = create_group("Errori", to_the_top=True)
+        group.setExpanded(True)
+        group.addLayer(error_layer)
 
         # Show attribute table
         iface.showAttributeTable(error_layer)
@@ -281,10 +285,14 @@ def load_qlr_layer(qlr_name, group=None):
     QgsLayerDefinition.loadLayerDefinition(qlr_file_path, QgsProject.instance(), group)
 
 
-def create_group(name, root=None):
+def create_group(name, root=None, to_the_top=False):
     if not root:
         root = QgsProject.instance().layerTreeRoot()
-    group = root.addGroup(name)
+
+    if to_the_top:
+        group = root.insertGroup(0, name)
+    else:
+        group = root.addGroup(name)
 
     return group
 


### PR DESCRIPTION
 + [x] Show input layer errors in their own group, at the top of the layer tree.

    ![image](https://github.com/user-attachments/assets/f0160151-cc82-4f20-b786-306ccaeba3d1)

 + [x] For each error in the error output layer bring the corresponding input feature's id (by matching message field in both error output/invalid output layers).

    ![Screenshot from 2025-03-04 16-59-11](https://github.com/user-attachments/assets/1a92858d-3ed4-4558-8dc7-39efdebeb5da)

 + [x] Duplicate node should not be shown as error since they will be removed by pzp_utils:fix_geometries algorithm. (Compare the following screenshot with the screenshot above)

    ![image](https://github.com/user-attachments/assets/dc6ff06f-a243-46ad-b6f2-3ad56b63e288)
