### PR TITLE
Caduta sassi, zone sorgenti

### DIFF
--- a/pzp/add_process.py
+++ b/pzp/add_process.py
@@ -97,8 +97,6 @@ def add_process(process_type, gpkg_directory_path):
         utils.set_value_relation_field(
             area_gpkg_layer, "fonte_proc", source_zones_gpkg_layer, "fonte_proc", "fonte_proc"
         )
-        utils.remove_not_null_constraint_to_field(area_gpkg_layer, "fonte_proc")
-        utils.remove_unique_constraint_to_field(area_gpkg_layer, "fonte_proc")
 
         # Propagation layer
         propagation_layer = utils.create_layer("Probabilità di propagazione (tutti gli scenari)", "LineString")
@@ -135,6 +133,8 @@ End
 
         utils.set_qml_style(propagation_layer, "propagation", True)
         utils.set_default_value_to_field(propagation_layer, "proc_parz", "@pzp_process")
+        utils.set_not_null_constraint_to_field(propagation_layer, "fonte_proc")
+        utils.remove_unique_constraint_to_field(propagation_layer, "fonte_proc")
 
         utils.add_layer_to_gpkg(propagation_layer, gpkg_path)
         propagation_gpkg_layer = utils.load_gpkg_layer(propagation_layer.name(), gpkg_path)

--- a/pzp/add_process.py
+++ b/pzp/add_process.py
@@ -217,6 +217,9 @@ End
         QgsExpressionContextUtils.setLayerVariable(breaking_gpkg_layer, "pzp_layer", "breaking")
         QgsExpressionContextUtils.setLayerVariable(breaking_gpkg_layer, "pzp_process", process_type)
 
+        # Remove 'impatto presente' category
+        utils.remove_renderer_category(breaking_gpkg_layer, "1001")
+
         group_breaking_filtered = utils.create_group("Probabilità di rottura", group)
         group_breaking_filtered.setExpanded(True)
 
@@ -227,14 +230,10 @@ End
         options.setGeometryChecks(["QgsIsValidCheck"])
 
         filter_params = [
-            ("\"prob_rottura\"='1003'", "Probabilità di rottura alta (0-30)", True),
-            ("\"prob_rottura\"='1002'", "Probabilità di rottura media (30-100)", True),
-            ("\"prob_rottura\"='1001'", "Probabilità di rottura bassa (100-300)", True),
-            (
-                "\"prob_rottura\"='1000'",
-                "Probabilità di rottura molto bassa (>300)",
-                False,
-            ),
+            ("\"prob_rottura\"='1003'", "Probabilità di rottura alta (0-30)", True, True),
+            ("\"prob_rottura\"='1002'", "Probabilità di rottura media (30-100)", True, True),
+            ("\"prob_rottura\"='1001'", "Probabilità di rottura bassa (100-300)", True, True),
+            ("\"prob_rottura\"='1000'", "Probabilità di rottura molto bassa (>300)", False, False),
         ]
 
         for param in filter_params:
@@ -244,15 +243,18 @@ End
                 param[0],
                 param[1],
             )
-
             added_layer = project.addMapLayer(gpkg_layer, False)
+
             if not param[2]:
                 utils.set_qml_style(added_layer, "breaking_without_no_impact")
+
+            if param[3]:  # Remove 'impatto presente' category
+                utils.remove_renderer_category(added_layer, "1001")
+
             group_breaking_filtered.addLayer(added_layer)
             layer_node = group.findLayer(added_layer.id())
             layer_node.setExpanded(False)
             layer_node.setItemVisibilityChecked(False)
-
     else:
         intensity_layer = utils.create_layer("Intensità completa")
 

--- a/pzp/add_process.py
+++ b/pzp/add_process.py
@@ -53,19 +53,19 @@ def add_process(process_type, gpkg_directory_path):
     QgsExpressionContextUtils.setLayerVariable(area_layer, "pzp_layer", "area")
     QgsExpressionContextUtils.setLayerVariable(area_layer, "pzp_process", process_type)
 
-    utils.add_field_to_layer(area_layer, "commento", "Osservazione o ev. commento", QVariant.String)
-
-    utils.add_field_to_layer(area_layer, "proc_parz", "Processo rappresentato TI", QVariant.Int)
+    utils.add_field_to_layer(area_layer, "commento", "Nome", QVariant.String)
+    utils.add_field_to_layer(area_layer, "proc_parz", "Processo", QVariant.Int)
     utils.set_value_map_to_field(area_layer, "proc_parz", domains.PROCESS_TYPES)
-
-    utils.add_field_to_layer(area_layer, "fonte_proc", "Fonte del processo (es. nome riale)", QVariant.String)
+    utils.add_field_to_layer(area_layer, "fonte_proc", "Fonte processo", QVariant.String)
 
     utils.set_qml_style(area_layer, "area")
+
     utils.set_not_null_constraint_to_field(area_layer, "fonte_proc")
     utils.set_unique_constraint_to_field(area_layer, "fonte_proc")
     utils.set_default_value_to_field(area_layer, "proc_parz", "@pzp_process")
     utils.set_not_null_constraint_to_field(area_layer, "proc_parz")
     utils.remove_unique_constraint_to_field(area_layer, "proc_parz")
+
     utils.add_layer_to_gpkg(area_layer, gpkg_path)
     area_gpkg_layer = utils.load_gpkg_layer(area_layer.name(), gpkg_path)
     project.addMapLayer(area_gpkg_layer, False)

--- a/pzp/add_process.py
+++ b/pzp/add_process.py
@@ -120,8 +120,16 @@ def add_process(process_type, gpkg_directory_path):
         utils.set_qml_style(propagation_layer, "propagation")
         utils.set_not_null_constraint_to_field(propagation_layer, "fonte_proc")
         utils.remove_unique_constraint_to_field(propagation_layer, "fonte_proc")
+
+        description = """Case
+    when "scenario"  = 0 then 'Sconosciuto'
+    when "scenario"  = 1001 then 'Scenario puntuale'
+    when "scenario"  = 1000 then 'Scenario diffuso'
+    else '_'
+End
+        """
         utils.set_value_relation_field(
-            propagation_layer, "fonte_proc", source_zones_gpkg_layer, "fonte_proc", "fonte_proc"
+            propagation_layer, "fonte_proc", source_zones_gpkg_layer, "fonte_proc", "fonte_proc", description
         )
 
         utils.add_layer_to_gpkg(propagation_layer, gpkg_path)
@@ -191,8 +199,15 @@ def add_process(process_type, gpkg_directory_path):
         utils.set_default_value_to_field(breaking_layer, "proc_parz", "@pzp_process")
 
         utils.set_qml_style(breaking_layer, "breaking")
+        description = """Case
+    when "scenario"  = 0 then 'Sconosciuto'
+    when "scenario"  = 1001 then 'Scenario puntuale'
+    when "scenario"  = 1000 then 'Scenario diffuso'
+    else '_'
+End
+        """
         utils.set_value_relation_field(
-            breaking_layer, "fonte_proc", source_zones_gpkg_layer, "fonte_proc", "fonte_proc"
+            breaking_layer, "fonte_proc", source_zones_gpkg_layer, "fonte_proc", "fonte_proc", description
         )
 
         utils.add_layer_to_gpkg(breaking_layer, gpkg_path)

--- a/pzp/calculation.py
+++ b/pzp/calculation.py
@@ -163,10 +163,10 @@ class PropagationTool:
         group_intensity_filtered.addLayer(new_layer)
 
         filter_params = [
-            ("\"periodo_ritorno\"='30'", "T 30"),
-            ("\"periodo_ritorno\"='100'", "T 100"),
-            ("\"periodo_ritorno\"='300'", "T 300"),
-            ("\"periodo_ritorno\">'300'", "T >300"),
+            ("\"periodo_ritorno\"='30'", "T 30", True),
+            ("\"periodo_ritorno\"='100'", "T 100", True),
+            ("\"periodo_ritorno\"='300'", "T 300", True),
+            ("\"periodo_ritorno\">'300'", "T >300", False),
         ]
 
         for param in filter_params:
@@ -177,6 +177,9 @@ class PropagationTool:
                 param[1],
             )
             utils.set_qml_style(gpkg_layer, "intensity")
+
+            if param[2]:  # Remove 'impatto presente' category
+                utils.remove_renderer_category(gpkg_layer, "1001")
 
             project.addMapLayer(gpkg_layer, False)
             group_intensity_filtered.addLayer(gpkg_layer)

--- a/pzp/processing/domains.py
+++ b/pzp/processing/domains.py
@@ -54,6 +54,13 @@ DANGER_LEVELS = OrderedDict(
     }
 )
 
+SOURCE_ZONES = OrderedDict(
+    {
+        1000: "Diffuso",
+        1001: "Puntuale",
+    }
+)
+
 PROCESS_TYPES = OrderedDict(
     {
         1110: "Alluvionamento corso d'acqua minore",

--- a/pzp/qml/area.qml
+++ b/pzp/qml/area.qml
@@ -1,82 +1,111 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.16.12-Hannover" labelsEnabled="0" styleCategories="LayerConfiguration|Symbology|Labeling|Fields|Forms" readOnly="0">
+<qgis version="3.43.0-Master" readOnly="0" styleCategories="LayerConfiguration|Symbology|Labeling|Fields|Forms" labelsEnabled="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
+    <Private>0</Private>
   </flags>
-  <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
+  <renderer-v2 type="singleSymbol" referencescale="-1" forceraster="0" enableorderby="0" symbollevels="0">
     <symbols>
-      <symbol type="fill" name="0" clip_to_extent="1" alpha="1" force_rhr="0">
-        <layer enabled="1" class="SimpleFill" locked="0" pass="0">
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="0,0,255,0" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="31,120,250,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.46" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+      <symbol type="fill" name="0" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{e2908301-c6cc-40b6-86af-baf59f9dbd5e}" pass="0" locked="0" enabled="1" class="SimpleFill">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,0,255,0,rgb:0,0,1,0" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="31,120,250,255,rgb:0.12156862745098039,0.47058823529411764,0.98039215686274506,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.46" name="outline_width"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
-          <prop v="45" k="angle"/>
-          <prop v="0,0,0,255" k="color"/>
-          <prop v="2" k="distance"/>
-          <prop v="3x:0,0,0,0,0,0" k="distance_map_unit_scale"/>
-          <prop v="MM" k="distance_unit"/>
-          <prop v="0.5" k="line_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
+        <layer id="{fa66d403-2161-4206-abd4-5fa7fab3fc2c}" pass="0" locked="0" enabled="1" class="LinePatternFill">
+          <Option type="Map">
+            <Option type="QString" value="45" name="angle"/>
+            <Option type="QString" value="during_render" name="clip_mode"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="color"/>
+            <Option type="QString" value="feature" name="coordinate_reference"/>
+            <Option type="QString" value="2" name="distance"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="distance_map_unit_scale"/>
+            <Option type="QString" value="MM" name="distance_unit"/>
+            <Option type="QString" value="0.5" name="line_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="line_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol type="line" name="@0@1" clip_to_extent="1" alpha="1" force_rhr="0">
-            <layer enabled="1" class="SimpleLine" locked="0" pass="0">
-              <prop v="0" k="align_dash_pattern"/>
-              <prop v="square" k="capstyle"/>
-              <prop v="5;2" k="customdash"/>
-              <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-              <prop v="MM" k="customdash_unit"/>
-              <prop v="0" k="dash_pattern_offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-              <prop v="MM" k="dash_pattern_offset_unit"/>
-              <prop v="0" k="draw_inside_polygon"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="31,120,180,255" k="line_color"/>
-              <prop v="solid" k="line_style"/>
-              <prop v="0.15" k="line_width"/>
-              <prop v="MM" k="line_width_unit"/>
-              <prop v="0" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="MM" k="offset_unit"/>
-              <prop v="0" k="ring_filter"/>
-              <prop v="0" k="tweak_dash_pattern_on_corners"/>
-              <prop v="0" k="use_custom_dash"/>
-              <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <symbol type="line" name="@0@1" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer id="{d5875839-1bb3-4e74-8b0b-85cca81b4357}" pass="0" locked="0" enabled="1" class="SimpleLine">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="31,120,180,255,rgb:0.12156862745098039,0.47058823529411764,0.70588235294117652,1" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.15" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" name="name" value=""/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option type="QString" name="type" value="collection"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -86,81 +115,271 @@
     </symbols>
     <rotation/>
     <sizescale/>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol type="fill" name="" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{6b17d3ff-6506-4e7d-b467-92ae3d6174ac}" pass="0" locked="0" enabled="1" class="SimpleFill">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,0,255,255,rgb:0,0,1,1" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.26" name="outline_width"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style fontUnderline="0" fontFamily="Open Sans" fontItalic="0" fontKerning="1" namedStyle="Regular" tabStopDistance="80" fontWordSpacing="0" isExpression="0" multilineHeight="1" allowHtml="0" fontStrikeout="0" forcedItalic="0" textOpacity="1" textColor="50,50,50,255,rgb:0.19607843137254902,0.19607843137254902,0.19607843137254902,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" fontSize="10" tabStopDistanceUnit="Point" legendString="Aa" fontSizeUnit="Point" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedBold="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" textOrientation="horizontal" blendMode="0" fieldName="commento" capitalization="0" useSubstitutions="0" fontWeight="50" fontLetterSpacing="0" multilineHeightUnit="Percentage">
+        <families/>
+        <text-buffer bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferColor="250,250,250,255,rgb:0.98039215686274506,0.98039215686274506,0.98039215686274506,1" bufferOpacity="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="128" bufferDraw="0" bufferSizeUnits="MM"/>
+        <text-mask maskEnabled="0" maskJoinStyle="128" maskSizeUnits="MM" maskType="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskedSymbolLayers="" maskSize="1.5" maskSize2="1.5" maskOpacity="1"/>
+        <background shapeRadiiY="0" shapeJoinStyle="64" shapeBorderWidthUnit="Point" shapeRadiiX="0" shapeBlendMode="0" shapeType="0" shapeSizeY="0" shapeOffsetUnit="Point" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRotation="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeBorderWidth="0" shapeOffsetX="0" shapeSizeUnit="Point" shapeSizeX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0" shapeSizeType="0" shapeRadiiUnit="Point" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeOffsetY="0" shapeSVGFile="" shapeOpacity="1">
+          <symbol type="marker" name="markerSymbol" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer id="" pass="0" locked="0" enabled="1" class="SimpleMarker">
+              <Option type="Map">
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="190,207,80,255,rgb:0.74509803921568629,0.81176470588235294,0.31372549019607843,1" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="circle" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="2" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MM" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+          <symbol type="fill" name="fillSymbol" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer id="" pass="0" locked="0" enabled="1" class="SimpleFill">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                <Option type="QString" value="no" name="outline_style"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="Point" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowDraw="0" shadowRadiusAlphaOnly="0" shadowOpacity="0.69999999999999996" shadowUnder="0" shadowRadiusUnit="MM" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetUnit="MM" shadowOffsetDist="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format rightDirectionSymbol=">" decimals="3" plussign="0" useMaxLineLengthForAutoWrap="1" leftDirectionSymbol="&lt;" addDirectionSymbol="0" autoWrapLength="0" formatNumbers="0" multilineAlign="3" wrapChar="" reverseDirectionSymbol="0" placeDirectionSymbol="0"/>
+      <placement lineAnchorPercent="0.5" repeatDistanceUnits="MM" rotationUnit="AngleDegrees" overlapHandling="PreventOverlap" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidWhole="0" repeatDistance="0" rotationAngle="0" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="10" offsetUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" overrunDistance="0" geometryGeneratorType="PointGeometry" placement="0" offsetType="0" distUnits="MM" lineAnchorClipping="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" lineAnchorType="0" allowDegraded="0" dist="0" geometryGeneratorEnabled="0" centroidInside="0" maximumDistance="0" geometryGenerator="" maximumDistanceUnit="MM" yOffset="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" lineAnchorTextPoint="FollowPlacement" maxCurvedCharAngleOut="-25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" maxCurvedCharAngleIn="25" quadOffset="4" fitInPolygonOnly="0" layerType="PolygonGeometry" prioritization="PreferCloser" priority="5" overrunDistanceUnit="MM" polygonPlacementFlags="2"/>
+      <rendering fontMinPixelSize="3" scaleMax="0" minFeatureSize="0" upsidedownLabels="0" fontMaxPixelSize="10000" fontLimitPixelSize="0" obstacleType="1" labelPerPart="0" drawLabels="1" obstacleFactor="1" scaleVisibility="0" scaleMin="0" obstacle="1" maxNumLabels="2000" limitNumLabels="0" mergeLines="0" zIndex="0" unplacedVisibility="0"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option name="properties"/>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+          <Option type="int" value="0" name="blendMode"/>
+          <Option type="Map" name="ddProperties">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+          <Option type="bool" value="false" name="drawToAllParts"/>
+          <Option type="QString" value="0" name="enabled"/>
+          <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+          <Option type="QString" value="&lt;symbol type=&quot;line&quot; name=&quot;symbol&quot; frame_rate=&quot;10&quot; is_animated=&quot;0&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer id=&quot;{7f395ec5-2e03-40ab-a071-df4a4fd4db6e}&quot; pass=&quot;0&quot; locked=&quot;0&quot; enabled=&quot;1&quot; class=&quot;SimpleLine&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+          <Option type="double" value="0" name="minLength"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+          <Option type="QString" value="MM" name="minLengthUnit"/>
+          <Option type="double" value="0" name="offsetFromAnchor"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+          <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+          <Option type="double" value="0" name="offsetFromLabel"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+          <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field name="fid" configurationFlags="None">
+    <field name="fid" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="commento" configurationFlags="None">
+    <field name="commento" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="proc_parz" configurationFlags="None">
+    <field name="proc_parz" configurationFlags="NoFlag">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" name="Alluvionamento corso d'acqua minore" value="1110"/>
+                <Option type="QString" value="1110" name="Alluvionamento corso d'acqua minore"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Alluvionamento corso d'acqua principale" value="1120"/>
+                <Option type="QString" value="1120" name="Alluvionamento corso d'acqua principale"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Colata detritica di versante" value="2002"/>
+                <Option type="QString" value="2002" name="Colata detritica di versante"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Flusso detrito" value="1200"/>
+                <Option type="QString" value="1200" name="Flusso detrito"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Ruscellamento superficiale" value="1400"/>
+                <Option type="QString" value="1400" name="Ruscellamento superficiale"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Scivolamento spontaneo" value="2001"/>
+                <Option type="QString" value="2001" name="Scivolamento spontaneo"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Caduta sassi o blocchi" value="3000"/>
+                <Option type="QString" value="3000" name="Caduta sassi o blocchi"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Valanga radente" value="4100"/>
+                <Option type="QString" value="4100" name="Valanga radente"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Valanga polverosa" value="4200"/>
+                <Option type="QString" value="4200" name="Valanga polverosa"/>
               </Option>
             </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="fonte_proc" configurationFlags="None">
-      <editWidget type="TextEdit">
+    <field name="fonte_proc" configurationFlags="NoFlag">
+      <editWidget type="ValueRelation">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="invalid" name="Description"/>
+            <Option type="invalid" name="FilterExpression"/>
+            <Option type="QString" value="fonte_proc" name="Key"/>
+            <Option type="QString" value="Zone_instabilita_1ed06e0b_ac25_48cb_a1ae_d42c8a2f4097" name="Layer"/>
+            <Option type="QString" value="Zona sorgente (fonte processo)" name="LayerName"/>
+            <Option type="QString" value="ogr" name="LayerProviderName"/>
+            <Option type="QString" value="F:/UPIP/06_StrumentiGis/02_Progetti base/09_Plugin QGIS/01_Test QGIS/Mod.proc.CadutaSassi2024/data_3000_19092023_145610.gpkg|layername=Zone_instabilita" name="LayerSource"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="fonte_proc" name="Value"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" name="" field="fid"/>
-    <alias index="1" name="Commento" field="commento"/>
-    <alias index="2" name="Processo" field="proc_parz"/>
-    <alias index="3" name="Fonte processo" field="fonte_proc"/>
+    <alias field="fid" name="" index="0"/>
+    <alias field="commento" name="Nome" index="1"/>
+    <alias field="proc_parz" name="Processo" index="2"/>
+    <alias field="fonte_proc" name="Fonte processo" index="3"/>
   </aliases>
+  <splitPolicies>
+    <policy field="fid" policy="Duplicate"/>
+    <policy field="commento" policy="Duplicate"/>
+    <policy field="proc_parz" policy="Duplicate"/>
+    <policy field="fonte_proc" policy="Duplicate"/>
+  </splitPolicies>
+  <duplicatePolicies>
+    <policy field="fid" policy="Duplicate"/>
+    <policy field="commento" policy="Duplicate"/>
+    <policy field="proc_parz" policy="Duplicate"/>
+    <policy field="fonte_proc" policy="Duplicate"/>
+  </duplicatePolicies>
   <defaults>
     <default field="fid" applyOnUpdate="0" expression=""/>
     <default field="commento" applyOnUpdate="0" expression=""/>
@@ -168,16 +387,16 @@
     <default field="fonte_proc" applyOnUpdate="0" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" exp_strength="0" field="fid" constraints="3" notnull_strength="1"/>
-    <constraint unique_strength="0" exp_strength="0" field="commento" constraints="0" notnull_strength="0"/>
-    <constraint unique_strength="0" exp_strength="0" field="proc_parz" constraints="1" notnull_strength="1"/>
-    <constraint unique_strength="1" exp_strength="0" field="fonte_proc" constraints="3" notnull_strength="1"/>
+    <constraint constraints="3" notnull_strength="1" field="fid" exp_strength="0" unique_strength="1"/>
+    <constraint constraints="0" notnull_strength="0" field="commento" exp_strength="0" unique_strength="0"/>
+    <constraint constraints="1" notnull_strength="1" field="proc_parz" exp_strength="0" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" field="fonte_proc" exp_strength="0" unique_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="fid" exp="" desc=""/>
-    <constraint field="commento" exp="" desc=""/>
-    <constraint field="proc_parz" exp="" desc=""/>
-    <constraint field="fonte_proc" exp="" desc=""/>
+    <constraint exp="" field="fid" desc=""/>
+    <constraint exp="" field="commento" desc=""/>
+    <constraint exp="" field="proc_parz" desc=""/>
+    <constraint exp="" field="fonte_proc" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -204,15 +423,35 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField index="2" showLabel="1" name="proc_parz"/>
-    <attributeEditorField index="3" showLabel="1" name="fonte_proc"/>
-    <attributeEditorField index="1" showLabel="1" name="commento"/>
+    <labelStyle labelColor="" overrideLabelColor="0" overrideLabelFont="0">
+      <labelFont italic="0" bold="0" style="" strikethrough="0" description="Ubuntu Sans,11,-1,5,50,0,0,0,0,0" underline="0"/>
+    </labelStyle>
+    <attributeEditorContainer type="Tab" collapsedExpressionEnabled="0" name="Attributi" showLabel="1" collapsedExpression="" verticalStretch="0" groupBox="0" collapsed="0" columnCount="1" visibilityExpression="" horizontalStretch="0" visibilityExpressionEnabled="0">
+      <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+        <labelFont italic="0" bold="0" style="" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+      </labelStyle>
+      <attributeEditorField name="proc_parz" showLabel="1" verticalStretch="0" horizontalStretch="0" index="2">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont italic="0" bold="0" style="" strikethrough="0" description="Noto Sans,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorField name="commento" showLabel="1" verticalStretch="0" horizontalStretch="0" index="1">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont italic="0" bold="0" style="" strikethrough="0" description="Noto Sans,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorField name="fonte_proc" showLabel="1" verticalStretch="0" horizontalStretch="0" index="3">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont italic="0" bold="0" style="" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+        </labelStyle>
+      </attributeEditorField>
+    </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="commento"/>
-    <field editable="1" name="fid"/>
-    <field editable="1" name="fonte_proc"/>
-    <field editable="0" name="proc_parz"/>
+    <field name="commento" editable="1"/>
+    <field name="fid" editable="1"/>
+    <field name="fonte_proc" editable="1"/>
+    <field name="proc_parz" editable="0"/>
   </editable>
   <labelOnTop>
     <field name="commento" labelOnTop="0"/>
@@ -220,6 +459,12 @@ def my_form_open(dialog, layer, feature):
     <field name="fonte_proc" labelOnTop="0"/>
     <field name="proc_parz" labelOnTop="0"/>
   </labelOnTop>
+  <reuseLastValue>
+    <field name="commento" reuseLastValue="0"/>
+    <field name="fid" reuseLastValue="0"/>
+    <field name="fonte_proc" reuseLastValue="0"/>
+    <field name="proc_parz" reuseLastValue="0"/>
+  </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
   <previewExpression>"commento"</previewExpression>

--- a/pzp/qml/breaking.qml
+++ b/pzp/qml/breaking.qml
@@ -1,121 +1,134 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.16.12-Hannover" styleCategories="Symbology|Labeling|Fields|Forms" labelsEnabled="0">
-  <renderer-v2 type="categorizedSymbol" symbollevels="1" forceraster="0" attr="classe_intensita" enableorderby="0">
+<qgis labelsEnabled="1" styleCategories="Symbology|Labeling|Forms" version="3.43.0-Master">
+  <renderer-v2 attr="classe_intensita" symbollevels="1" type="categorizedSymbol" forceraster="0" enableorderby="0" referencescale="-1">
     <categories>
-      <category label="forte" render="true" value="1004" symbol="0"/>
-      <category label="medio" render="true" value="1003" symbol="1"/>
-      <category label="debole" render="true" value="1002" symbol="2"/>
-      <category label="impatto presente" render="true" value="1001" symbol="3"/>
+      <category type="string" symbol="0" label="forte" value="1004" render="true" uuid="0"/>
+      <category type="string" symbol="1" label="medio" value="1003" render="true" uuid="1"/>
+      <category type="string" symbol="2" label="debole" value="1002" render="true" uuid="2"/>
     </categories>
     <symbols>
-      <symbol type="fill" alpha="0.8" name="0" force_rhr="0" clip_to_extent="1">
-        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="56,158,0,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+      <symbol name="0" force_rhr="0" type="fill" is_animated="0" alpha="1" clip_to_extent="1" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" id="{94abfca8-01b7-4c99-a36b-f59232ed7149}" class="SimpleFill" enabled="1" pass="4">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="56,158,0,255,rgb:0.2196078431372549,0.61960784313725492,0,1"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="164,158,152,255,rgb:0.64313725490196083,0.61960784313725492,0.59607843137254901,1"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="fill" alpha="0.8" name="1" force_rhr="0" clip_to_extent="1">
-        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="83,212,0,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+      <symbol name="1" force_rhr="0" type="fill" is_animated="0" alpha="1" clip_to_extent="1" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" id="{5937fe56-ad81-4488-8643-70811f0973e4}" class="SimpleFill" enabled="1" pass="3">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="161,230,23,255,rgb:0.63137254901960782,0.90196078431372551,0.09019607843137255,1"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="130,130,130,255,rgb:0.50980392156862742,0.50980392156862742,0.50980392156862742,1"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="fill" alpha="0.8" name="2" force_rhr="0" clip_to_extent="1">
-        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="209,255,115,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+      <symbol name="2" force_rhr="0" type="fill" is_animated="0" alpha="1" clip_to_extent="1" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" id="{3c88ea54-dc31-4d70-acef-298608f23e13}" class="SimpleFill" enabled="1" pass="2">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="209,255,115,255,rgb:0.81960784313725488,1,0.45098039215686275,1"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="130,130,130,255,rgb:0.50980392156862742,0.50980392156862742,0.50980392156862742,1"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-      </symbol>
-      <symbol type="fill" alpha="0.8" name="3" force_rhr="0" clip_to_extent="1">
-        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="232,190,255,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option type="QString" name="name" value=""/>
-              <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <source-symbol>
-      <symbol type="fill" alpha="0.8" name="0" force_rhr="0" clip_to_extent="1">
-        <layer enabled="1" locked="0" class="SimpleFill" pass="0">
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="0,0,255,255"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.26"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+      <symbol name="0" force_rhr="0" type="fill" is_animated="0" alpha="1" clip_to_extent="1" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" id="{8ce54b97-d429-46bb-a47a-e3b9be66606f}" class="SimpleFill" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="237,76,44,255,rgb:0.92941176470588238,0.29803921568627451,0.17254901960784313,1"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="0,0,0,255,rgb:0,0,0,1"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" name="name" value=""/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option type="QString" name="type" value="collection"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -123,139 +136,312 @@
     </source-symbol>
     <rotation/>
     <sizescale/>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" type="QString" value=""/>
+        <Option name="properties"/>
+        <Option name="type" type="QString" value="collection"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol name="" force_rhr="0" type="fill" is_animated="0" alpha="1" clip_to_extent="1" frame_rate="10">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer locked="0" id="{7b8292bc-11ad-449a-9a1b-0bef97803fe7}" class="SimpleFill" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="0,0,255,255,rgb:0,0,1,1"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style fontSize="10" useSubstitutions="1" tabStopDistance="80" isExpression="0" fontWeight="50" allowHtml="0" forcedBold="0" blendMode="0" fontItalic="0" fontUnderline="0" fontSizeUnit="Point" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" textOrientation="horizontal" capitalization="0" legendString="Aa" fontStrikeout="0" fontLetterSpacing="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontFamily="Ubuntu Sans" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontKerning="1" multilineHeightUnit="Percentage" textOpacity="1" multilineHeight="1" fontWordSpacing="0" textColor="0,0,0,255,rgb:0,0,0,1" tabStopDistanceUnit="Point" fieldName="fonte_proc" forcedItalic="0" namedStyle="Regular">
+        <families/>
+        <text-buffer bufferSizeUnits="MM" bufferJoinStyle="128" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferSize="1" bufferNoFill="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferBlendMode="0" bufferOpacity="1" bufferDraw="0"/>
+        <text-mask maskOpacity="1" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskedSymbolLayers="" maskEnabled="0" maskType="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5"/>
+        <background shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeBlendMode="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotation="0" shapeOffsetY="0" shapeJoinStyle="64" shapeRadiiY="0" shapeOffsetX="0" shapeOpacity="1" shapeSizeX="0" shapeDraw="0" shapeRadiiUnit="MM" shapeSVGFile="" shapeSizeY="0" shapeSizeType="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBorderWidthUnit="MM" shapeOffsetUnit="MM" shapeRadiiX="0" shapeType="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSizeUnit="MM">
+          <symbol name="markerSymbol" force_rhr="0" type="marker" is_animated="0" alpha="1" clip_to_extent="1" frame_rate="10">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer locked="0" id="" class="SimpleMarker" enabled="1" pass="0">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"/>
+                <Option name="cap_style" type="QString" value="square"/>
+                <Option name="color" type="QString" value="114,155,111,255,rgb:0.44705882352941179,0.60784313725490191,0.43529411764705883,1"/>
+                <Option name="horizontal_anchor_point" type="QString" value="1"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="name" type="QString" value="circle"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1"/>
+                <Option name="outline_style" type="QString" value="solid"/>
+                <Option name="outline_width" type="QString" value="0"/>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="outline_width_unit" type="QString" value="MM"/>
+                <Option name="scale_method" type="QString" value="diameter"/>
+                <Option name="size" type="QString" value="2"/>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="size_unit" type="QString" value="MM"/>
+                <Option name="vertical_anchor_point" type="QString" value="1"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+          <symbol name="fillSymbol" force_rhr="0" type="fill" is_animated="0" alpha="1" clip_to_extent="1" frame_rate="10">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer locked="0" id="" class="SimpleFill" enabled="1" pass="0">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="color" type="QString" value="255,255,255,255,rgb:1,1,1,1"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1"/>
+                <Option name="outline_style" type="QString" value="no"/>
+                <Option name="outline_width" type="QString" value="0"/>
+                <Option name="outline_width_unit" type="QString" value="MM"/>
+                <Option name="style" type="QString" value="solid"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowBlendMode="6" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusAlphaOnly="0" shadowUnder="0" shadowOffsetUnit="MM" shadowRadius="1.5" shadowScale="100" shadowDraw="0" shadowOffsetDist="1" shadowRadiusUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </dd_properties>
+        <substitutions>
+          <replacement caseSensitive="0" match="1000" wholeWord="1" replace="0"/>
+          <replacement caseSensitive="0" match="1001" wholeWord="1" replace="9"/>
+          <replacement caseSensitive="0" match="1002" wholeWord="1" replace="8"/>
+          <replacement caseSensitive="0" match="1003" wholeWord="1" replace="7"/>
+          <replacement caseSensitive="0" match="1004" wholeWord="1" replace="6"/>
+          <replacement caseSensitive="0" match="1005" wholeWord="1" replace="5"/>
+          <replacement caseSensitive="0" match="1006" wholeWord="1" replace="4"/>
+          <replacement caseSensitive="0" match="1007" wholeWord="1" replace="3"/>
+          <replacement caseSensitive="0" match="1008" wholeWord="1" replace="2"/>
+          <replacement caseSensitive="0" match="1009" wholeWord="1" replace="1"/>
+          <replacement caseSensitive="0" match="1010" wholeWord="1" replace="-10"/>
+        </substitutions>
+      </text-style>
+      <text-format leftDirectionSymbol="&lt;" rightDirectionSymbol=">" reverseDirectionSymbol="0" autoWrapLength="0" decimals="3" formatNumbers="0" multilineAlign="0" plussign="0" useMaxLineLengthForAutoWrap="1" placeDirectionSymbol="0" wrapChar="" addDirectionSymbol="0"/>
+      <placement offsetType="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" offsetUnits="MM" repeatDistanceUnits="MM" dist="0" centroidInside="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" overlapHandling="PreventOverlap" overrunDistanceUnit="MM" quadOffset="4" lineAnchorPercent="0.5" lineAnchorType="0" placementFlags="10" prioritization="PreferCloser" xOffset="0" repeatDistance="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" lineAnchorTextPoint="CenterOfText" priority="5" lineAnchorClipping="0" maximumDistanceUnit="MM" geometryGeneratorType="PointGeometry" distUnits="MM" fitInPolygonOnly="0" layerType="PolygonGeometry" geometryGenerator="" geometryGeneratorEnabled="0" rotationAngle="0" distMapUnitScale="3x:0,0,0,0,0,0" centroidWhole="0" maxCurvedCharAngleIn="25" yOffset="0" maxCurvedCharAngleOut="-25" allowDegraded="0" polygonPlacementFlags="2" preserveRotation="1" placement="0" maximumDistance="0" overrunDistance="0"/>
+      <rendering scaleMax="0" zIndex="0" drawLabels="1" limitNumLabels="0" mergeLines="0" unplacedVisibility="0" scaleMin="0" fontLimitPixelSize="0" labelPerPart="0" fontMinPixelSize="3" fontMaxPixelSize="10000" obstacleType="0" minFeatureSize="0" upsidedownLabels="0" obstacle="1" scaleVisibility="0" obstacleFactor="1" maxNumLabels="2000"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option name="name" type="QString" value=""/>
+          <Option name="properties"/>
+          <Option name="type" type="QString" value="collection"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility"/>
+          <Option name="blendMode" type="int" value="0"/>
+          <Option name="ddProperties" type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+          <Option name="drawToAllParts" type="bool" value="false"/>
+          <Option name="enabled" type="QString" value="0"/>
+          <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"/>
+          <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; is_animated=&quot;0&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer locked=&quot;0&quot; id=&quot;{dc77551b-9ee5-47d2-8a14-60e7418d0a9f}&quot; class=&quot;SimpleLine&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/>&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/>&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot;/>&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/>&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/>&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
+          <Option name="minLength" type="double" value="0"/>
+          <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="minLengthUnit" type="QString" value="MM"/>
+          <Option name="offsetFromAnchor" type="double" value="0"/>
+          <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offsetFromAnchorUnit" type="QString" value="MM"/>
+          <Option name="offsetFromLabel" type="double" value="0"/>
+          <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offsetFromLabelUnit" type="QString" value="MM"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field name="fid" configurationFlags="None">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="osservazioni" configurationFlags="None">
+    <field name="fid">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" name="IsMultiline" value="false"/>
-            <Option type="bool" name="UseHtml" value="false"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="prob_rottura" configurationFlags="None">
+    <field name="prob_rottura">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" name="Alta" value="1003"/>
+                <Option name="molto bassa" type="QString" value="1000"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Media" value="1002"/>
+                <Option name="bassa" type="QString" value="1001"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Bassa" value="1001"/>
+                <Option name="media" type="QString" value="1002"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Molto bassa" value="1000"/>
+                <Option name="alta" type="QString" value="1003"/>
+              </Option>
+              <Option type="Map">
+                <Option name="&lt;NULL>" type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"/>
               </Option>
             </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="classe_intensita" configurationFlags="None">
+    <field name="classe_intensita">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" name="Impatto presente" value="1001"/>
+                <Option name="debole" type="QString" value="1002"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Debole" value="1002"/>
+                <Option name="medio" type="QString" value="1003"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Medio" value="1003"/>
+                <Option name="forte" type="QString" value="1004"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" name="Forte" value="1004"/>
+                <Option name="&lt;NULL>" type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"/>
               </Option>
             </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="fonte_proc" configurationFlags="None">
+    <field name="fonte_proc">
       <editWidget type="ValueRelation">
         <config>
           <Option type="Map">
-            <Option type="bool" name="AllowMulti" value="false"/>
-            <Option type="bool" name="AllowNull" value="false"/>
-            <Option type="QString" name="FilterExpression" value=""/>
-            <Option type="QString" name="Key" value="fonte_proc"/>
-            <Option type="QString" name="Layer" value="Area_di_studio_642ee896_7e7d_424e_bf79_062b44660254"/>
-            <Option type="bool" name="OrderByValue" value="false"/>
-            <Option type="bool" name="UseCompleter" value="false"/>
-            <Option type="QString" name="Value" value="fonte_proc"/>
+            <Option name="AllowMulti" type="bool" value="false"/>
+            <Option name="AllowNull" type="bool" value="false"/>
+            <Option name="Description" type="QString" value="Case&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 0 then 'Sconosciuto'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1001 then 'Scenario puntuale'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1000 then 'Scenario diffuso'&#xd;&#xa;&#x9;else '_'&#xd;&#xa;End"/>
+            <Option name="FilterExpression" type="invalid"/>
+            <Option name="Key" type="QString" value="fonte_proc"/>
+            <Option name="Layer" type="QString" value="Zone_instabilita_1ed06e0b_ac25_48cb_a1ae_d42c8a2f4097"/>
+            <Option name="LayerName" type="QString" value="Zona sorgente (fonte processo)"/>
+            <Option name="LayerProviderName" type="QString" value="ogr"/>
+            <Option name="LayerSource" type="QString" value="F:/UPIP/06_StrumentiGis/02_Progetti base/09_Plugin QGIS/01_Test QGIS/Mod.proc.CadutaSassi2024/data_3000_19092023_145610.gpkg|layername=Zone_instabilita"/>
+            <Option name="NofColumns" type="int" value="1"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="UseCompleter" type="bool" value="false"/>
+            <Option name="Value" type="QString" value="fonte_proc"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="proc_parz" configurationFlags="None">
+    <field name="proc_parz">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option name="map" type="List">
+              <Option type="Map">
+                <Option name="caduta sassi o blocchi" type="QString" value="3000"/>
+              </Option>
+              <Option type="Map">
+                <Option name="crollo di roccia o frana" type="QString" value="3001"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="commento">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="area">
       <editWidget type="Range">
         <config>
           <Option type="Map">
-            <Option type="bool" name="AllowNull" value="true"/>
-            <Option type="int" name="Max" value="2147483647"/>
-            <Option type="int" name="Min" value="-2147483648"/>
-            <Option type="int" name="Precision" value="0"/>
-            <Option type="int" name="Step" value="1"/>
-            <Option type="QString" name="Style" value="SpinBox"/>
+            <Option name="AllowNull" type="bool" value="true"/>
+            <Option name="Max" type="double" value="1.7976931348623157e+308"/>
+            <Option name="Min" type="double" value="-1.7976931348623157e+308"/>
+            <Option name="Precision" type="int" value="1"/>
+            <Option name="Step" type="double" value="1"/>
+            <Option name="Style" type="QString" value="SpinBox"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
-  <aliases>
-    <alias name="" index="0" field="fid"/>
-    <alias name="Osservazioni" index="1" field="osservazioni"/>
-    <alias name="Probabilità di rottura" index="2" field="prob_rottura"/>
-    <alias name="Intensità" index="3" field="classe_intensita"/>
-    <alias name="Fonte del processo" index="4" field="fonte_proc"/>
-    <alias name="Processo parziale" index="5" field="proc_parz"/>
-  </aliases>
-  <defaults>
-    <default expression="" applyOnUpdate="0" field="fid"/>
-    <default expression="" applyOnUpdate="0" field="osservazioni"/>
-    <default expression="" applyOnUpdate="0" field="prob_rottura"/>
-    <default expression="" applyOnUpdate="0" field="classe_intensita"/>
-    <default expression="" applyOnUpdate="0" field="fonte_proc"/>
-    <default expression=" @pzp_process" applyOnUpdate="0" field="proc_parz"/>
-  </defaults>
-  <constraints>
-    <constraint notnull_strength="1" unique_strength="1" constraints="3" exp_strength="0" field="fid"/>
-    <constraint notnull_strength="0" unique_strength="0" constraints="0" exp_strength="0" field="osservazioni"/>
-    <constraint notnull_strength="0" unique_strength="0" constraints="0" exp_strength="0" field="prob_rottura"/>
-    <constraint notnull_strength="0" unique_strength="0" constraints="0" exp_strength="0" field="classe_intensita"/>
-    <constraint notnull_strength="0" unique_strength="0" constraints="0" exp_strength="0" field="fonte_proc"/>
-    <constraint notnull_strength="0" unique_strength="0" constraints="0" exp_strength="0" field="proc_parz"/>
-  </constraints>
-  <constraintExpressions>
-    <constraint desc="" field="fid" exp=""/>
-    <constraint desc="" field="osservazioni" exp=""/>
-    <constraint desc="" field="prob_rottura" exp=""/>
-    <constraint desc="" field="classe_intensita" exp=""/>
-    <constraint desc="" field="fonte_proc" exp=""/>
-    <constraint desc="" field="proc_parz" exp=""/>
-  </constraintExpressions>
-  <expressionfields/>
   <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
-  <editforminitfilepath>/home/01_GeologiaValanghe/02_PZP/Capriasca_PZP/06_Estraz_dati/Dati inviati/Qgs/00_Pericoli naturali</editforminitfilepath>
+  <editforminitfilepath>/home/germap/01_GeologiaValanghe/02_PZP/Maggia_PZP/06_Estraz_dati/Dati inviati/Qgs/00_Pericoli naturali</editforminitfilepath>
   <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
@@ -276,17 +462,53 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpression="" groupBox="0" name="Dati principali" showLabel="1" columnCount="1" visibilityExpressionEnabled="0">
-      <attributeEditorField name="proc_parz" showLabel="1" index="5"/>
-      <attributeEditorField name="prob_rottura" showLabel="1" index="2"/>
-      <attributeEditorField name="classe_intensita" showLabel="1" index="3"/>
-      <attributeEditorField name="fonte_proc" showLabel="1" index="4"/>
-      <attributeEditorField name="osservazioni" showLabel="1" index="1"/>
-    </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpression="" groupBox="0" name="Dati secondari" showLabel="1" columnCount="1" visibilityExpressionEnabled="0">
-      <attributeEditorField name="proc_parz_ch" showLabel="1" index="-1"/>
-      <attributeEditorField name="liv_dettaglio" showLabel="1" index="-1"/>
-      <attributeEditorField name="scala" showLabel="1" index="-1"/>
+    <labelStyle labelColor="" overrideLabelColor="0" overrideLabelFont="0">
+      <labelFont italic="0" description="Ubuntu Sans,11,-1,5,50,0,0,0,0,0" bold="0" underline="0" strikethrough="0" style=""/>
+    </labelStyle>
+    <attributeEditorContainer name="Attributi" horizontalStretch="0" verticalStretch="0" collapsedExpression="" type="Tab" groupBox="0" showLabel="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" collapsedExpressionEnabled="0" collapsed="0">
+      <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+        <labelFont italic="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" underline="0" strikethrough="0" style=""/>
+      </labelStyle>
+      <attributeEditorField name="prob_rottura" horizontalStretch="0" verticalStretch="0" index="1" showLabel="1">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont italic="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" underline="0" strikethrough="0" style=""/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorField name="classe_intensita" horizontalStretch="0" verticalStretch="0" index="2" showLabel="1">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont italic="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" underline="0" strikethrough="0" style=""/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorField name="fonte_proc" horizontalStretch="0" verticalStretch="0" index="3" showLabel="1">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont italic="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" underline="0" strikethrough="0" style=""/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorField name="commento" horizontalStretch="0" verticalStretch="0" index="5" showLabel="1">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont italic="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" underline="0" strikethrough="0" style=""/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorContainer name="Automatici" horizontalStretch="0" verticalStretch="0" collapsedExpression="" type="GroupBox" groupBox="1" showLabel="1" columnCount="1" visibilityExpressionEnabled="0" visibilityExpression="" collapsedExpressionEnabled="0" collapsed="0">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont italic="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" underline="0" strikethrough="0" style=""/>
+        </labelStyle>
+        <attributeEditorField name="proc_parz" horizontalStretch="0" verticalStretch="0" index="4" showLabel="1">
+          <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont italic="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" underline="0" strikethrough="0" style=""/>
+          </labelStyle>
+        </attributeEditorField>
+        <attributeEditorField name="fid" horizontalStretch="0" verticalStretch="0" index="0" showLabel="1">
+          <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont italic="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" underline="0" strikethrough="0" style=""/>
+          </labelStyle>
+        </attributeEditorField>
+        <attributeEditorField name="area" horizontalStretch="0" verticalStretch="0" index="6" showLabel="1">
+          <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+            <labelFont italic="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" bold="0" underline="0" strikethrough="0" style=""/>
+          </labelStyle>
+        </attributeEditorField>
+      </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
@@ -303,28 +525,47 @@ def my_form_open(dialog, layer, feature):
     <field name="prob_accadimento" editable="1"/>
     <field name="prob_propagazione" editable="1"/>
     <field name="prob_rottura" editable="1"/>
-    <field name="proc_parz" editable="0"/>
+    <field name="proc_parz" editable="1"/>
     <field name="proc_parz_ch" editable="1"/>
     <field name="scala" editable="1"/>
+    <field name="scenari_prob_rottura" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="area"/>
-    <field labelOnTop="0" name="classe_intensita"/>
-    <field labelOnTop="1" name="commento"/>
-    <field labelOnTop="0" name="fid"/>
-    <field labelOnTop="0" name="fonte"/>
-    <field labelOnTop="0" name="fonte_proc"/>
-    <field labelOnTop="0" name="liv_dettaglio"/>
-    <field labelOnTop="0" name="matrice"/>
-    <field labelOnTop="0" name="osservazioni"/>
-    <field labelOnTop="0" name="periodo_ritorno"/>
-    <field labelOnTop="0" name="prob_accadimento"/>
-    <field labelOnTop="0" name="prob_propagazione"/>
-    <field labelOnTop="0" name="prob_rottura"/>
-    <field labelOnTop="0" name="proc_parz"/>
-    <field labelOnTop="0" name="proc_parz_ch"/>
-    <field labelOnTop="0" name="scala"/>
+    <field name="area" labelOnTop="0"/>
+    <field name="classe_intensita" labelOnTop="0"/>
+    <field name="commento" labelOnTop="1"/>
+    <field name="fid" labelOnTop="0"/>
+    <field name="fonte" labelOnTop="0"/>
+    <field name="fonte_proc" labelOnTop="0"/>
+    <field name="liv_dettaglio" labelOnTop="0"/>
+    <field name="matrice" labelOnTop="0"/>
+    <field name="osservazioni" labelOnTop="0"/>
+    <field name="periodo_ritorno" labelOnTop="0"/>
+    <field name="prob_accadimento" labelOnTop="0"/>
+    <field name="prob_propagazione" labelOnTop="0"/>
+    <field name="prob_rottura" labelOnTop="0"/>
+    <field name="proc_parz" labelOnTop="0"/>
+    <field name="proc_parz_ch" labelOnTop="0"/>
+    <field name="scala" labelOnTop="0"/>
+    <field name="scenari_prob_rottura" labelOnTop="0"/>
   </labelOnTop>
+  <reuseLastValue>
+    <field name="area" reuseLastValue="0"/>
+    <field name="classe_intensita" reuseLastValue="0"/>
+    <field name="commento" reuseLastValue="0"/>
+    <field name="fid" reuseLastValue="0"/>
+    <field name="fonte_proc" reuseLastValue="0"/>
+    <field name="liv_dettaglio" reuseLastValue="0"/>
+    <field name="matrice" reuseLastValue="0"/>
+    <field name="osservazioni" reuseLastValue="0"/>
+    <field name="periodo_ritorno" reuseLastValue="0"/>
+    <field name="prob_accadimento" reuseLastValue="0"/>
+    <field name="prob_propagazione" reuseLastValue="0"/>
+    <field name="prob_rottura" reuseLastValue="0"/>
+    <field name="proc_parz" reuseLastValue="0"/>
+    <field name="proc_parz_ch" reuseLastValue="0"/>
+    <field name="scala" reuseLastValue="0"/>
+  </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
   <layerGeometryType>2</layerGeometryType>

--- a/pzp/qml/propagation.qml
+++ b/pzp/qml/propagation.qml
@@ -1,454 +1,460 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Symbology|Fields|Forms" version="3.43.0-Master">
-  <renderer-v2 enableorderby="0" attr="prob_propagazione" type="categorizedSymbol" symbollevels="0" referencescale="-1" forceraster="0">
+<qgis labelsEnabled="1" styleCategories="LayerConfiguration|Symbology|Labeling|Forms" readOnly="0" version="3.43.0-Master">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <renderer-v2 enableorderby="0" referencescale="-1" type="categorizedSymbol" symbollevels="0" forceraster="0" attr="prob_propagazione">
     <categories>
-      <category label="alta" uuid="0" type="string" value="1003" symbol="0" render="true"/>
-      <category label="media" uuid="1" type="string" value="1002" symbol="1" render="true"/>
-      <category label="bassa" uuid="2" type="string" value="1001" symbol="2" render="true"/>
-      <category label="" uuid="3" type="string" value="" symbol="3" render="false"/>
+      <category render="true" uuid="0" value="1003" symbol="0" type="string" label="alta"/>
+      <category render="true" uuid="1" value="1002" symbol="1" type="string" label="media"/>
+      <category render="true" uuid="2" value="1001" symbol="2" type="string" label="bassa"/>
+      <category render="false" uuid="3" value="" symbol="3" type="string" label=""/>
     </categories>
     <symbols>
-      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="0">
+      <symbol force_rhr="0" type="line" frame_rate="10" alpha="1" is_animated="0" clip_to_extent="1" name="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" locked="0" pass="0" id="{a2791384-74e0-4a62-868a-88575f8e3b9b}" class="SimpleLine">
+        <layer id="{a2791384-74e0-4a62-868a-88575f8e3b9b}" pass="0" class="SimpleLine" enabled="1" locked="0">
           <Option type="Map">
-            <Option type="QString" value="0" name="align_dash_pattern"/>
-            <Option type="QString" value="square" name="capstyle"/>
-            <Option type="QString" value="5;2" name="customdash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-            <Option type="QString" value="MM" name="customdash_unit"/>
-            <Option type="QString" value="0" name="dash_pattern_offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-            <Option type="QString" value="0" name="draw_inside_polygon"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="227,26,28,255,rgb:0.8901960784313725,0.10196078431372549,0.10980392156862745,1" name="line_color"/>
-            <Option type="QString" value="solid" name="line_style"/>
-            <Option type="QString" value="0.26" name="line_width"/>
-            <Option type="QString" value="MM" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="0" name="trim_distance_end"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-            <Option type="QString" value="0" name="trim_distance_start"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-            <Option type="QString" value="0" name="use_custom_dash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="227,26,28,255,rgb:0.8901960784313725,0.10196078431372549,0.10980392156862745,1" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="0.26" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" locked="0" pass="0" id="{0780e612-1b38-4295-b40e-d59c11913cca}" class="MarkerLine">
+        <layer id="{0780e612-1b38-4295-b40e-d59c11913cca}" pass="0" class="MarkerLine" enabled="1" locked="0">
           <Option type="Map">
-            <Option type="QString" value="4" name="average_angle_length"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="average_angle_map_unit_scale"/>
-            <Option type="QString" value="MM" name="average_angle_unit"/>
-            <Option type="QString" value="20" name="interval"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="interval_map_unit_scale"/>
-            <Option type="QString" value="Point" name="interval_unit"/>
-            <Option type="QString" value="-0.6" name="offset"/>
-            <Option type="QString" value="0.5" name="offset_along_line"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_along_line_map_unit_scale"/>
-            <Option type="QString" value="Point" name="offset_along_line_unit"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="bool" value="true" name="place_on_every_part"/>
-            <Option type="QString" value="Interval" name="placements"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="1" name="rotate"/>
+            <Option value="4" type="QString" name="average_angle_length"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="average_angle_map_unit_scale"/>
+            <Option value="MM" type="QString" name="average_angle_unit"/>
+            <Option value="20" type="QString" name="interval"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="interval_map_unit_scale"/>
+            <Option value="Point" type="QString" name="interval_unit"/>
+            <Option value="-0.6" type="QString" name="offset"/>
+            <Option value="0.5" type="QString" name="offset_along_line"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_along_line_map_unit_scale"/>
+            <Option value="Point" type="QString" name="offset_along_line_unit"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="true" type="bool" name="place_on_every_part"/>
+            <Option value="Interval" type="QString" name="placements"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="1" type="QString" name="rotate"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="marker" force_rhr="0" name="@0@1">
+          <symbol force_rhr="0" type="marker" frame_rate="10" alpha="1" is_animated="0" clip_to_extent="1" name="@0@1">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer enabled="1" locked="0" pass="0" id="{2d747dd0-d5d1-422d-8d8d-bce1270a9abd}" class="SimpleMarker">
+            <layer id="{2d747dd0-d5d1-422d-8d8d-bce1270a9abd}" pass="0" class="SimpleMarker" enabled="1" locked="0">
               <Option type="Map">
-                <Option type="QString" value="0" name="angle"/>
-                <Option type="QString" value="square" name="cap_style"/>
-                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="color"/>
-                <Option type="QString" value="1" name="horizontal_anchor_point"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="equilateral_triangle" name="name"/>
-                <Option type="QString" value="4.40000000000000036,4.40000000000000036" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="Point" name="offset_unit"/>
-                <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="outline_color"/>
-                <Option type="QString" value="solid" name="outline_style"/>
-                <Option type="QString" value="0" name="outline_width"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-                <Option type="QString" value="MM" name="outline_width_unit"/>
-                <Option type="QString" value="area" name="scale_method"/>
-                <Option type="QString" value="10" name="size"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
-                <Option type="QString" value="Pixel" name="size_unit"/>
-                <Option type="QString" value="1" name="vertical_anchor_point"/>
+                <Option value="0" type="QString" name="angle"/>
+                <Option value="square" type="QString" name="cap_style"/>
+                <Option value="0,0,0,255,rgb:0,0,0,1" type="QString" name="color"/>
+                <Option value="1" type="QString" name="horizontal_anchor_point"/>
+                <Option value="bevel" type="QString" name="joinstyle"/>
+                <Option value="equilateral_triangle" type="QString" name="name"/>
+                <Option value="4.40000000000000036,4.40000000000000036" type="QString" name="offset"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                <Option value="Point" type="QString" name="offset_unit"/>
+                <Option value="255,255,255,255,rgb:1,1,1,1" type="QString" name="outline_color"/>
+                <Option value="solid" type="QString" name="outline_style"/>
+                <Option value="0" type="QString" name="outline_width"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+                <Option value="MM" type="QString" name="outline_width_unit"/>
+                <Option value="area" type="QString" name="scale_method"/>
+                <Option value="10" type="QString" name="size"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+                <Option value="Pixel" type="QString" name="size_unit"/>
+                <Option value="1" type="QString" name="vertical_anchor_point"/>
               </Option>
-              <effect enabled="0" type="effectStack">
+              <effect type="effectStack" enabled="0">
                 <effect type="drawSource">
                   <Option type="Map">
-                    <Option type="QString" value="0" name="blend_mode"/>
-                    <Option type="QString" value="2" name="draw_mode"/>
-                    <Option type="QString" value="1" name="enabled"/>
-                    <Option type="QString" value="1" name="opacity"/>
+                    <Option value="0" type="QString" name="blend_mode"/>
+                    <Option value="2" type="QString" name="draw_mode"/>
+                    <Option value="1" type="QString" name="enabled"/>
+                    <Option value="1" type="QString" name="opacity"/>
                   </Option>
                 </effect>
               </effect>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="1">
+      <symbol force_rhr="0" type="line" frame_rate="10" alpha="1" is_animated="0" clip_to_extent="1" name="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" locked="0" pass="0" id="{1570a05b-798d-4f86-84ee-299d3e67dbce}" class="SimpleLine">
+        <layer id="{1570a05b-798d-4f86-84ee-299d3e67dbce}" pass="0" class="SimpleLine" enabled="1" locked="0">
           <Option type="Map">
-            <Option type="QString" value="0" name="align_dash_pattern"/>
-            <Option type="QString" value="square" name="capstyle"/>
-            <Option type="QString" value="5;2" name="customdash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-            <Option type="QString" value="MM" name="customdash_unit"/>
-            <Option type="QString" value="0" name="dash_pattern_offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-            <Option type="QString" value="0" name="draw_inside_polygon"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="255,127,0,255,rgb:1,0.49803921568627452,0,1" name="line_color"/>
-            <Option type="QString" value="dash" name="line_style"/>
-            <Option type="QString" value="1.08" name="line_width"/>
-            <Option type="QString" value="Point" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="Point" name="offset_unit"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="0" name="trim_distance_end"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-            <Option type="QString" value="0" name="trim_distance_start"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-            <Option type="QString" value="0" name="use_custom_dash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="255,127,0,255,rgb:1,0.49803921568627452,0,1" type="QString" name="line_color"/>
+            <Option value="dash" type="QString" name="line_style"/>
+            <Option value="1.08" type="QString" name="line_width"/>
+            <Option value="Point" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="Point" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" locked="0" pass="0" id="{46ebdb28-028d-406d-8ca8-032d55f1045e}" class="MarkerLine">
+        <layer id="{46ebdb28-028d-406d-8ca8-032d55f1045e}" pass="0" class="MarkerLine" enabled="1" locked="0">
           <Option type="Map">
-            <Option type="QString" value="4" name="average_angle_length"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="average_angle_map_unit_scale"/>
-            <Option type="QString" value="MM" name="average_angle_unit"/>
-            <Option type="QString" value="20" name="interval"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="interval_map_unit_scale"/>
-            <Option type="QString" value="Point" name="interval_unit"/>
-            <Option type="QString" value="-0.6" name="offset"/>
-            <Option type="QString" value="0.5" name="offset_along_line"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_along_line_map_unit_scale"/>
-            <Option type="QString" value="Point" name="offset_along_line_unit"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="Point" name="offset_unit"/>
-            <Option type="bool" value="true" name="place_on_every_part"/>
-            <Option type="QString" value="Interval" name="placements"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="1" name="rotate"/>
+            <Option value="4" type="QString" name="average_angle_length"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="average_angle_map_unit_scale"/>
+            <Option value="MM" type="QString" name="average_angle_unit"/>
+            <Option value="20" type="QString" name="interval"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="interval_map_unit_scale"/>
+            <Option value="Point" type="QString" name="interval_unit"/>
+            <Option value="-0.6" type="QString" name="offset"/>
+            <Option value="0.5" type="QString" name="offset_along_line"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_along_line_map_unit_scale"/>
+            <Option value="Point" type="QString" name="offset_along_line_unit"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="Point" type="QString" name="offset_unit"/>
+            <Option value="true" type="bool" name="place_on_every_part"/>
+            <Option value="Interval" type="QString" name="placements"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="1" type="QString" name="rotate"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="marker" force_rhr="0" name="@1@1">
+          <symbol force_rhr="0" type="marker" frame_rate="10" alpha="1" is_animated="0" clip_to_extent="1" name="@1@1">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer enabled="1" locked="0" pass="0" id="{11d2cf12-bb1d-4943-9f61-cdea4c34c49a}" class="SimpleMarker">
+            <layer id="{11d2cf12-bb1d-4943-9f61-cdea4c34c49a}" pass="0" class="SimpleMarker" enabled="1" locked="0">
               <Option type="Map">
-                <Option type="QString" value="0" name="angle"/>
-                <Option type="QString" value="square" name="cap_style"/>
-                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="color"/>
-                <Option type="QString" value="1" name="horizontal_anchor_point"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="equilateral_triangle" name="name"/>
-                <Option type="QString" value="4.40000000000000036,4.40000000000000036" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="Point" name="offset_unit"/>
-                <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="outline_color"/>
-                <Option type="QString" value="solid" name="outline_style"/>
-                <Option type="QString" value="0" name="outline_width"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-                <Option type="QString" value="MM" name="outline_width_unit"/>
-                <Option type="QString" value="diameter" name="scale_method"/>
-                <Option type="QString" value="10" name="size"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
-                <Option type="QString" value="Pixel" name="size_unit"/>
-                <Option type="QString" value="1" name="vertical_anchor_point"/>
+                <Option value="0" type="QString" name="angle"/>
+                <Option value="square" type="QString" name="cap_style"/>
+                <Option value="0,0,0,255,rgb:0,0,0,1" type="QString" name="color"/>
+                <Option value="1" type="QString" name="horizontal_anchor_point"/>
+                <Option value="bevel" type="QString" name="joinstyle"/>
+                <Option value="equilateral_triangle" type="QString" name="name"/>
+                <Option value="4.40000000000000036,4.40000000000000036" type="QString" name="offset"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                <Option value="Point" type="QString" name="offset_unit"/>
+                <Option value="255,255,255,255,rgb:1,1,1,1" type="QString" name="outline_color"/>
+                <Option value="solid" type="QString" name="outline_style"/>
+                <Option value="0" type="QString" name="outline_width"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+                <Option value="MM" type="QString" name="outline_width_unit"/>
+                <Option value="diameter" type="QString" name="scale_method"/>
+                <Option value="10" type="QString" name="size"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+                <Option value="Pixel" type="QString" name="size_unit"/>
+                <Option value="1" type="QString" name="vertical_anchor_point"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="2">
+      <symbol force_rhr="0" type="line" frame_rate="10" alpha="1" is_animated="0" clip_to_extent="1" name="2">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" locked="0" pass="0" id="{a1c724e9-0289-481e-ac21-f3fc86225f70}" class="SimpleLine">
+        <layer id="{a1c724e9-0289-481e-ac21-f3fc86225f70}" pass="0" class="SimpleLine" enabled="1" locked="0">
           <Option type="Map">
-            <Option type="QString" value="0" name="align_dash_pattern"/>
-            <Option type="QString" value="square" name="capstyle"/>
-            <Option type="QString" value="5;2" name="customdash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-            <Option type="QString" value="MM" name="customdash_unit"/>
-            <Option type="QString" value="0" name="dash_pattern_offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-            <Option type="QString" value="0" name="draw_inside_polygon"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="line_color"/>
-            <Option type="QString" value="dot" name="line_style"/>
-            <Option type="QString" value="1.08" name="line_width"/>
-            <Option type="QString" value="Point" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="0" name="trim_distance_end"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-            <Option type="QString" value="0" name="trim_distance_start"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-            <Option type="QString" value="0" name="use_custom_dash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="line_color"/>
+            <Option value="dot" type="QString" name="line_style"/>
+            <Option value="1.08" type="QString" name="line_width"/>
+            <Option value="Point" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" locked="0" pass="0" id="{71305106-e631-4c6e-b111-8a6b4780542d}" class="MarkerLine">
+        <layer id="{71305106-e631-4c6e-b111-8a6b4780542d}" pass="0" class="MarkerLine" enabled="1" locked="0">
           <Option type="Map">
-            <Option type="QString" value="4" name="average_angle_length"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="average_angle_map_unit_scale"/>
-            <Option type="QString" value="MM" name="average_angle_unit"/>
-            <Option type="QString" value="20" name="interval"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="interval_map_unit_scale"/>
-            <Option type="QString" value="Point" name="interval_unit"/>
-            <Option type="QString" value="-0.6" name="offset"/>
-            <Option type="QString" value="0.5" name="offset_along_line"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_along_line_map_unit_scale"/>
-            <Option type="QString" value="Point" name="offset_along_line_unit"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="Point" name="offset_unit"/>
-            <Option type="bool" value="true" name="place_on_every_part"/>
-            <Option type="QString" value="Interval" name="placements"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="1" name="rotate"/>
+            <Option value="4" type="QString" name="average_angle_length"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="average_angle_map_unit_scale"/>
+            <Option value="MM" type="QString" name="average_angle_unit"/>
+            <Option value="20" type="QString" name="interval"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="interval_map_unit_scale"/>
+            <Option value="Point" type="QString" name="interval_unit"/>
+            <Option value="-0.6" type="QString" name="offset"/>
+            <Option value="0.5" type="QString" name="offset_along_line"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_along_line_map_unit_scale"/>
+            <Option value="Point" type="QString" name="offset_along_line_unit"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="Point" type="QString" name="offset_unit"/>
+            <Option value="true" type="bool" name="place_on_every_part"/>
+            <Option value="Interval" type="QString" name="placements"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="1" type="QString" name="rotate"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="marker" force_rhr="0" name="@2@1">
+          <symbol force_rhr="0" type="marker" frame_rate="10" alpha="1" is_animated="0" clip_to_extent="1" name="@2@1">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer enabled="1" locked="0" pass="0" id="{16f6e03c-63c4-4eb2-9ea8-3b448ef38d88}" class="SimpleMarker">
+            <layer id="{16f6e03c-63c4-4eb2-9ea8-3b448ef38d88}" pass="0" class="SimpleMarker" enabled="1" locked="0">
               <Option type="Map">
-                <Option type="QString" value="0" name="angle"/>
-                <Option type="QString" value="square" name="cap_style"/>
-                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="color"/>
-                <Option type="QString" value="1" name="horizontal_anchor_point"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="equilateral_triangle" name="name"/>
-                <Option type="QString" value="4.40000000000000036,4.40000000000000036" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="Point" name="offset_unit"/>
-                <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="outline_color"/>
-                <Option type="QString" value="solid" name="outline_style"/>
-                <Option type="QString" value="0" name="outline_width"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-                <Option type="QString" value="MM" name="outline_width_unit"/>
-                <Option type="QString" value="diameter" name="scale_method"/>
-                <Option type="QString" value="10" name="size"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
-                <Option type="QString" value="Point" name="size_unit"/>
-                <Option type="QString" value="1" name="vertical_anchor_point"/>
+                <Option value="0" type="QString" name="angle"/>
+                <Option value="square" type="QString" name="cap_style"/>
+                <Option value="0,0,0,255,rgb:0,0,0,1" type="QString" name="color"/>
+                <Option value="1" type="QString" name="horizontal_anchor_point"/>
+                <Option value="bevel" type="QString" name="joinstyle"/>
+                <Option value="equilateral_triangle" type="QString" name="name"/>
+                <Option value="4.40000000000000036,4.40000000000000036" type="QString" name="offset"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                <Option value="Point" type="QString" name="offset_unit"/>
+                <Option value="255,255,255,255,rgb:1,1,1,1" type="QString" name="outline_color"/>
+                <Option value="solid" type="QString" name="outline_style"/>
+                <Option value="0" type="QString" name="outline_width"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+                <Option value="MM" type="QString" name="outline_width_unit"/>
+                <Option value="diameter" type="QString" name="scale_method"/>
+                <Option value="10" type="QString" name="size"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+                <Option value="Point" type="QString" name="size_unit"/>
+                <Option value="1" type="QString" name="vertical_anchor_point"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="3">
+      <symbol force_rhr="0" type="line" frame_rate="10" alpha="1" is_animated="0" clip_to_extent="1" name="3">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" locked="0" pass="0" id="{48d18e69-644a-468d-894a-16eca28a21de}" class="SimpleLine">
+        <layer id="{48d18e69-644a-468d-894a-16eca28a21de}" pass="0" class="SimpleLine" enabled="1" locked="0">
           <Option type="Map">
-            <Option type="QString" value="0" name="align_dash_pattern"/>
-            <Option type="QString" value="square" name="capstyle"/>
-            <Option type="QString" value="5;2" name="customdash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-            <Option type="QString" value="MM" name="customdash_unit"/>
-            <Option type="QString" value="0" name="dash_pattern_offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-            <Option type="QString" value="0" name="draw_inside_polygon"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="63,52,215,255,rgb:0.24705882352941178,0.20392156862745098,0.84313725490196079,1" name="line_color"/>
-            <Option type="QString" value="solid" name="line_style"/>
-            <Option type="QString" value="0.26" name="line_width"/>
-            <Option type="QString" value="MM" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="0" name="trim_distance_end"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-            <Option type="QString" value="0" name="trim_distance_start"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-            <Option type="QString" value="0" name="use_custom_dash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="63,52,215,255,rgb:0.24705882352941178,0.20392156862745098,0.84313725490196079,1" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="0.26" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <source-symbol>
-      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="0">
+      <symbol force_rhr="0" type="line" frame_rate="10" alpha="1" is_animated="0" clip_to_extent="1" name="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" locked="0" pass="0" id="{9ae01466-4608-4766-94c0-b24ba15276f7}" class="SimpleLine">
+        <layer id="{9ae01466-4608-4766-94c0-b24ba15276f7}" pass="0" class="SimpleLine" enabled="1" locked="0">
           <Option type="Map">
-            <Option type="QString" value="0" name="align_dash_pattern"/>
-            <Option type="QString" value="square" name="capstyle"/>
-            <Option type="QString" value="5;2" name="customdash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-            <Option type="QString" value="MM" name="customdash_unit"/>
-            <Option type="QString" value="0" name="dash_pattern_offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-            <Option type="QString" value="0" name="draw_inside_polygon"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="line_color"/>
-            <Option type="QString" value="solid" name="line_style"/>
-            <Option type="QString" value="0.26" name="line_width"/>
-            <Option type="QString" value="MM" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="0" name="trim_distance_end"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-            <Option type="QString" value="0" name="trim_distance_start"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-            <Option type="QString" value="0" name="use_custom_dash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="0.26" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -458,230 +464,307 @@
     <sizescale/>
     <data-defined-properties>
       <Option type="Map">
-        <Option type="QString" value="" name="name"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </data-defined-properties>
   </renderer-v2>
   <selection mode="Default">
     <selectionColor invalid="1"/>
     <selectionSymbol>
-      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="">
+      <symbol force_rhr="0" type="line" frame_rate="10" alpha="1" is_animated="0" clip_to_extent="1" name="">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" locked="0" pass="0" id="{d5117ecb-cdb1-45f7-a06f-c78c342e2626}" class="SimpleLine">
+        <layer id="{d5117ecb-cdb1-45f7-a06f-c78c342e2626}" pass="0" class="SimpleLine" enabled="1" locked="0">
           <Option type="Map">
-            <Option type="QString" value="0" name="align_dash_pattern"/>
-            <Option type="QString" value="square" name="capstyle"/>
-            <Option type="QString" value="5;2" name="customdash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-            <Option type="QString" value="MM" name="customdash_unit"/>
-            <Option type="QString" value="0" name="dash_pattern_offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-            <Option type="QString" value="0" name="draw_inside_polygon"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="line_color"/>
-            <Option type="QString" value="solid" name="line_style"/>
-            <Option type="QString" value="0.26" name="line_width"/>
-            <Option type="QString" value="MM" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="0" name="trim_distance_end"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-            <Option type="QString" value="0" name="trim_distance_start"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-            <Option type="QString" value="0" name="use_custom_dash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="0.26" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </selectionSymbol>
   </selection>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style multilineHeightUnit="Percentage" fontKerning="1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" blendMode="0" legendString="Aa" forcedItalic="0" allowHtml="0" fontSize="10" fontLetterSpacing="0" fieldName="prob_propagazione" forcedBold="0" tabStopDistanceUnit="Point" fontWeight="50" fontFamily="Open Sans" fontItalic="0" multilineHeight="1" textOpacity="1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" tabStopDistance="80" isExpression="0" namedStyle="Regular" fontWordSpacing="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" textColor="50,50,50,255,rgb:0.19607843137254902,0.19607843137254902,0.19607843137254902,1" fontStrikeout="0" fontUnderline="0" capitalization="0" useSubstitutions="1" textOrientation="horizontal">
+        <families/>
+        <text-buffer bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferOpacity="1" bufferColor="250,250,250,255,rgb:0.98039215686274506,0.98039215686274506,0.98039215686274506,1" bufferNoFill="1" bufferBlendMode="0" bufferSize="1" bufferDraw="0" bufferJoinStyle="128"/>
+        <text-mask maskOpacity="1" maskType="0" maskEnabled="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskSize="1.5" maskSize2="1.5" maskedSymbolLayers="" maskSizeUnits="MM" maskJoinStyle="128"/>
+        <background shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="Point" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOffsetUnit="Point" shapeRotation="0" shapeSizeType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="Point" shapeOffsetY="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeOffsetX="0" shapeType="0" shapeRadiiUnit="Point" shapeBorderWidth="0" shapeRadiiY="0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeSizeY="0" shapeSizeX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSVGFile="" shapeDraw="0" shapeBlendMode="0" shapeOpacity="1" shapeRotationType="0" shapeRadiiX="0">
+          <symbol force_rhr="0" type="marker" frame_rate="10" alpha="1" is_animated="0" clip_to_extent="1" name="markerSymbol">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option value="" type="QString" name="name"/>
+                <Option name="properties"/>
+                <Option value="collection" type="QString" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer id="" pass="0" class="SimpleMarker" enabled="1" locked="0">
+              <Option type="Map">
+                <Option value="0" type="QString" name="angle"/>
+                <Option value="square" type="QString" name="cap_style"/>
+                <Option value="152,125,183,255,rgb:0.59607843137254901,0.49019607843137253,0.71764705882352942,1" type="QString" name="color"/>
+                <Option value="1" type="QString" name="horizontal_anchor_point"/>
+                <Option value="bevel" type="QString" name="joinstyle"/>
+                <Option value="circle" type="QString" name="name"/>
+                <Option value="0,0" type="QString" name="offset"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                <Option value="MM" type="QString" name="offset_unit"/>
+                <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                <Option value="solid" type="QString" name="outline_style"/>
+                <Option value="0" type="QString" name="outline_width"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+                <Option value="MM" type="QString" name="outline_width_unit"/>
+                <Option value="diameter" type="QString" name="scale_method"/>
+                <Option value="2" type="QString" name="size"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+                <Option value="MM" type="QString" name="size_unit"/>
+                <Option value="1" type="QString" name="vertical_anchor_point"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+          <symbol force_rhr="0" type="fill" frame_rate="10" alpha="1" is_animated="0" clip_to_extent="1" name="fillSymbol">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option value="" type="QString" name="name"/>
+                <Option name="properties"/>
+                <Option value="collection" type="QString" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer id="" pass="0" class="SimpleFill" enabled="1" locked="0">
+              <Option type="Map">
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                <Option value="255,255,255,255,rgb:1,1,1,1" type="QString" name="color"/>
+                <Option value="bevel" type="QString" name="joinstyle"/>
+                <Option value="0,0" type="QString" name="offset"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                <Option value="MM" type="QString" name="offset_unit"/>
+                <Option value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString" name="outline_color"/>
+                <Option value="no" type="QString" name="outline_style"/>
+                <Option value="0" type="QString" name="outline_width"/>
+                <Option value="Point" type="QString" name="outline_width_unit"/>
+                <Option value="solid" type="QString" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowDraw="0" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowUnder="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowBlendMode="6" shadowOffsetUnit="MM" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadiusAlphaOnly="0" shadowScale="100" shadowOffsetAngle="135" shadowRadius="1.5"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </dd_properties>
+        <substitutions>
+          <replacement replace="bassa" caseSensitive="0" wholeWord="1" match="1001"/>
+          <replacement replace="media" caseSensitive="0" wholeWord="1" match="1002"/>
+          <replacement replace="alta" caseSensitive="0" wholeWord="1" match="1003"/>
+        </substitutions>
+      </text-style>
+      <text-format formatNumbers="0" addDirectionSymbol="0" placeDirectionSymbol="0" autoWrapLength="0" rightDirectionSymbol=">" useMaxLineLengthForAutoWrap="1" leftDirectionSymbol="&lt;" wrapChar="" reverseDirectionSymbol="0" decimals="3" plussign="0" multilineAlign="0"/>
+      <placement overlapHandling="PreventOverlap" offsetType="0" repeatDistanceUnits="MM" yOffset="0" lineAnchorPercent="0.5" layerType="LineGeometry" geometryGenerator="" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" maxCurvedCharAngleIn="25" overrunDistance="0" distMapUnitScale="3x:0,0,0,0,0,0" centroidInside="0" prioritization="PreferCloser" lineAnchorType="0" maximumDistance="0" fitInPolygonOnly="0" maximumDistanceUnit="MM" quadOffset="4" lineAnchorClipping="0" repeatDistance="0" maxCurvedCharAngleOut="-25" xOffset="0" polygonPlacementFlags="2" dist="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" placement="2" lineAnchorTextPoint="FollowPlacement" centroidWhole="0" geometryGeneratorEnabled="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorType="PointGeometry" rotationAngle="0" preserveRotation="1" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" offsetUnits="MM" priority="5" distUnits="MM" allowDegraded="0" overrunDistanceUnit="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="10"/>
+      <rendering minFeatureSize="0" fontLimitPixelSize="0" labelPerPart="0" zIndex="0" mergeLines="0" obstacleFactor="1" scaleMax="0" maxNumLabels="2000" fontMinPixelSize="3" scaleVisibility="0" scaleMin="0" obstacle="1" drawLabels="1" fontMaxPixelSize="10000" obstacleType="1" unplacedVisibility="0" upsidedownLabels="0" limitNumLabels="0"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option value="" type="QString" name="name"/>
+          <Option name="properties"/>
+          <Option value="collection" type="QString" name="type"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option value="pole_of_inaccessibility" type="QString" name="anchorPoint"/>
+          <Option value="0" type="int" name="blendMode"/>
+          <Option type="Map" name="ddProperties">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+          <Option value="false" type="bool" name="drawToAllParts"/>
+          <Option value="0" type="QString" name="enabled"/>
+          <Option value="point_on_exterior" type="QString" name="labelAnchorPoint"/>
+          <Option value="&lt;symbol force_rhr=&quot;0&quot; type=&quot;line&quot; frame_rate=&quot;10&quot; alpha=&quot;1&quot; is_animated=&quot;0&quot; clip_to_extent=&quot;1&quot; name=&quot;symbol&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; type=&quot;QString&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; type=&quot;QString&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer id=&quot;{a5e7a18b-ef3c-456c-87d8-06764edc77c8}&quot; pass=&quot;0&quot; class=&quot;SimpleLine&quot; enabled=&quot;1&quot; locked=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option value=&quot;square&quot; type=&quot;QString&quot; name=&quot;capstyle&quot;/>&lt;Option value=&quot;5;2&quot; type=&quot;QString&quot; name=&quot;customdash&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;customdash_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option value=&quot;bevel&quot; type=&quot;QString&quot; name=&quot;joinstyle&quot;/>&lt;Option value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot; name=&quot;line_color&quot;/>&lt;Option value=&quot;solid&quot; type=&quot;QString&quot; name=&quot;line_style&quot;/>&lt;Option value=&quot;0.3&quot; type=&quot;QString&quot; name=&quot;line_width&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;line_width_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;offset&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;offset_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;ring_filter&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;trim_distance_end&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;trim_distance_start&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;use_custom_dash&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; type=&quot;QString&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; type=&quot;QString&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString" name="lineSymbol"/>
+          <Option value="0" type="double" name="minLength"/>
+          <Option value="3x:0,0,0,0,0,0" type="QString" name="minLengthMapUnitScale"/>
+          <Option value="MM" type="QString" name="minLengthUnit"/>
+          <Option value="0" type="double" name="offsetFromAnchor"/>
+          <Option value="3x:0,0,0,0,0,0" type="QString" name="offsetFromAnchorMapUnitScale"/>
+          <Option value="MM" type="QString" name="offsetFromAnchorUnit"/>
+          <Option value="0" type="double" name="offsetFromLabel"/>
+          <Option value="3x:0,0,0,0,0,0" type="QString" name="offsetFromLabelMapUnitScale"/>
+          <Option value="MM" type="QString" name="offsetFromLabelUnit"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field configurationFlags="NoFlag" name="fid">
+    <field name="fid">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="prob_propagazione">
+    <field name="prob_propagazione">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" value="1001" name="bassa"/>
+                <Option value="1001" type="QString" name="bassa"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1002" name="media"/>
+                <Option value="1002" type="QString" name="media"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1003" name="alta"/>
+                <Option value="1003" type="QString" name="alta"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>"/>
+                <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" type="QString" name="&lt;NULL>"/>
               </Option>
             </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="fonte_proc">
+    <field name="fonte_proc">
       <editWidget type="ValueRelation">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="AllowMulti"/>
-            <Option type="bool" value="false" name="AllowNull"/>
-            <Option type="QString" value="Case&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 0 then 'Sconosciuto'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1001 then 'Scenario puntuale'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1000 then 'Scenario diffuso'&#xd;&#xa;&#x9;else '_'&#xd;&#xa;End" name="Description"/>
+            <Option value="false" type="bool" name="AllowMulti"/>
+            <Option value="false" type="bool" name="AllowNull"/>
+            <Option value="Case&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 0 then 'Sconosciuto'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1001 then 'Scenario puntuale'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1000 then 'Scenario diffuso'&#xd;&#xa;&#x9;else '_'&#xd;&#xa;End" type="QString" name="Description"/>
             <Option type="invalid" name="FilterExpression"/>
-            <Option type="QString" value="fonte_proc" name="Key"/>
-            <Option type="QString" value="Zone_instabilita_1ed06e0b_ac25_48cb_a1ae_d42c8a2f4097" name="Layer"/>
-            <Option type="QString" value="Zona sorgente (fonte processo)" name="LayerName"/>
-            <Option type="QString" value="ogr" name="LayerProviderName"/>
-            <Option type="QString" value="F:/UPIP/06_StrumentiGis/02_Progetti base/09_Plugin QGIS/01_Test QGIS/Mod.proc.CadutaSassi2024/data_3000_19092023_145610.gpkg|layername=Zone_instabilita" name="LayerSource"/>
-            <Option type="int" value="1" name="NofColumns"/>
-            <Option type="bool" value="false" name="OrderByValue"/>
-            <Option type="bool" value="false" name="UseCompleter"/>
-            <Option type="QString" value="fonte_proc" name="Value"/>
+            <Option value="fonte_proc" type="QString" name="Key"/>
+            <Option value="Zone_instabilita_1ed06e0b_ac25_48cb_a1ae_d42c8a2f4097" type="QString" name="Layer"/>
+            <Option value="Zona sorgente (fonte processo)" type="QString" name="LayerName"/>
+            <Option value="ogr" type="QString" name="LayerProviderName"/>
+            <Option value="F:/UPIP/06_StrumentiGis/02_Progetti base/09_Plugin QGIS/01_Test QGIS/Mod.proc.CadutaSassi2024/data_3000_19092023_145610.gpkg|layername=Zone_instabilita" type="QString" name="LayerSource"/>
+            <Option value="1" type="int" name="NofColumns"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="UseCompleter"/>
+            <Option value="fonte_proc" type="QString" name="Value"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="prob_rottura">
+    <field name="prob_rottura">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" value="1000" name="molto bassa"/>
+                <Option value="1000" type="QString" name="molto bassa"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1001" name="bassa"/>
+                <Option value="1001" type="QString" name="bassa"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1002" name="media"/>
+                <Option value="1002" type="QString" name="media"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1003" name="alta"/>
+                <Option value="1003" type="QString" name="alta"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>"/>
+                <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" type="QString" name="&lt;NULL>"/>
               </Option>
             </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="proc_parz">
+    <field name="proc_parz">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" value="3000" name="caduta sassi o blocchi"/>
+                <Option value="3000" type="QString" name="caduta sassi o blocchi"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="3001" name="crollo di roccia o frana"/>
+                <Option value="3001" type="QString" name="crollo di roccia o frana"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>"/>
+                <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" type="QString" name="&lt;NULL>"/>
               </Option>
             </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="lunghezza">
+    <field name="lunghezza">
       <editWidget type="Range">
         <config>
           <Option type="Map">
-            <Option type="bool" value="true" name="AllowNull"/>
-            <Option type="double" value="1.7976931348623157e+308" name="Max"/>
-            <Option type="double" value="-1.7976931348623157e+308" name="Min"/>
-            <Option type="int" value="1" name="Precision"/>
-            <Option type="double" value="1" name="Step"/>
-            <Option type="QString" value="SpinBox" name="Style"/>
+            <Option value="true" type="bool" name="AllowNull"/>
+            <Option value="1.7976931348623157e+308" type="double" name="Max"/>
+            <Option value="-1.7976931348623157e+308" type="double" name="Min"/>
+            <Option value="1" type="int" name="Precision"/>
+            <Option value="1" type="double" name="Step"/>
+            <Option value="SpinBox" type="QString" name="Style"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
-  <aliases>
-    <alias index="0" field="fid" name="Identificativo (automatico)"/>
-    <alias index="1" field="prob_propagazione" name="Limite probabilità di propagazione"/>
-    <alias index="2" field="fonte_proc" name="Zona sorgente (fonte processo)"/>
-    <alias index="3" field="prob_rottura" name="Probabilità di rottura (scenario)"/>
-    <alias index="4" field="proc_parz" name="Processo rappresentato TI"/>
-    <alias index="5" field="lunghezza" name="Lunghezza in metri"/>
-  </aliases>
-  <splitPolicies>
-    <policy field="fid" policy="Duplicate"/>
-    <policy field="prob_propagazione" policy="Duplicate"/>
-    <policy field="fonte_proc" policy="Duplicate"/>
-    <policy field="prob_rottura" policy="Duplicate"/>
-    <policy field="proc_parz" policy="Duplicate"/>
-    <policy field="lunghezza" policy="Duplicate"/>
-  </splitPolicies>
-  <duplicatePolicies>
-    <policy field="fid" policy="Duplicate"/>
-    <policy field="prob_propagazione" policy="Duplicate"/>
-    <policy field="fonte_proc" policy="Duplicate"/>
-    <policy field="prob_rottura" policy="Duplicate"/>
-    <policy field="proc_parz" policy="Duplicate"/>
-    <policy field="lunghezza" policy="Duplicate"/>
-  </duplicatePolicies>
-  <defaults>
-    <default expression="" field="fid" applyOnUpdate="0"/>
-    <default expression="" field="prob_propagazione" applyOnUpdate="0"/>
-    <default expression="" field="fonte_proc" applyOnUpdate="0"/>
-    <default expression="" field="prob_rottura" applyOnUpdate="0"/>
-    <default expression=" @pzp_process" field="proc_parz" applyOnUpdate="0"/>
-    <default expression="" field="lunghezza" applyOnUpdate="0"/>
-  </defaults>
-  <constraints>
-    <constraint unique_strength="1" exp_strength="0" constraints="3" field="fid" notnull_strength="1"/>
-    <constraint unique_strength="0" exp_strength="0" constraints="0" field="prob_propagazione" notnull_strength="0"/>
-    <constraint unique_strength="0" exp_strength="0" constraints="0" field="fonte_proc" notnull_strength="0"/>
-    <constraint unique_strength="0" exp_strength="0" constraints="0" field="prob_rottura" notnull_strength="0"/>
-    <constraint unique_strength="0" exp_strength="0" constraints="0" field="proc_parz" notnull_strength="0"/>
-    <constraint unique_strength="0" exp_strength="0" constraints="0" field="lunghezza" notnull_strength="0"/>
-  </constraints>
-  <constraintExpressions>
-    <constraint exp="" desc="" field="fid"/>
-    <constraint exp="" desc="" field="prob_propagazione"/>
-    <constraint exp="" desc="" field="fonte_proc"/>
-    <constraint exp="" desc="" field="prob_rottura"/>
-    <constraint exp="" desc="" field="proc_parz"/>
-    <constraint exp="" desc="" field="lunghezza"/>
-  </constraintExpressions>
-  <expressionfields>
-    <field precision="0" comment="" expression=" $length " subType="0" typeName="double precision" type="6" length="-1" name="lunghezza"/>
-  </expressionfields>
   <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
@@ -705,45 +788,45 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>2</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <labelStyle labelColor="" overrideLabelFont="0" overrideLabelColor="0">
-      <labelFont bold="0" strikethrough="0" description="Ubuntu Sans,11,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+    <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="">
+      <labelFont description="Ubuntu Sans,11,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0" bold="0" strikethrough="0"/>
     </labelStyle>
-    <attributeEditorContainer collapsedExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" horizontalStretch="0" collapsed="0" verticalStretch="0" visibilityExpressionEnabled="0" columnCount="1" type="Tab" name="Attributi" collapsedExpression="">
-      <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-        <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+    <attributeEditorContainer columnCount="1" collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" visibilityExpressionEnabled="0" horizontalStretch="0" verticalStretch="0" type="Tab" visibilityExpression="" groupBox="0" showLabel="1" name="Attributi">
+      <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+        <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0" bold="0" strikethrough="0"/>
       </labelStyle>
-      <attributeEditorField index="1" showLabel="1" horizontalStretch="0" verticalStretch="0" name="prob_propagazione">
-        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-          <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+      <attributeEditorField horizontalStretch="0" verticalStretch="0" index="1" showLabel="1" name="prob_propagazione">
+        <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0" bold="0" strikethrough="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField index="3" showLabel="1" horizontalStretch="0" verticalStretch="0" name="prob_rottura">
-        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-          <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+      <attributeEditorField horizontalStretch="0" verticalStretch="0" index="3" showLabel="1" name="prob_rottura">
+        <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0" bold="0" strikethrough="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField index="2" showLabel="1" horizontalStretch="0" verticalStretch="0" name="fonte_proc">
-        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-          <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+      <attributeEditorField horizontalStretch="0" verticalStretch="0" index="2" showLabel="1" name="fonte_proc">
+        <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0" bold="0" strikethrough="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorContainer collapsedExpressionEnabled="0" groupBox="1" visibilityExpression="" showLabel="1" horizontalStretch="0" collapsed="0" verticalStretch="0" visibilityExpressionEnabled="0" columnCount="1" type="GroupBox" name="Automatici" collapsedExpression="">
-        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-          <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+      <attributeEditorContainer columnCount="1" collapsed="0" collapsedExpression="" collapsedExpressionEnabled="0" visibilityExpressionEnabled="0" horizontalStretch="0" verticalStretch="0" type="GroupBox" visibilityExpression="" groupBox="1" showLabel="1" name="Automatici">
+        <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0" bold="0" strikethrough="0"/>
         </labelStyle>
-        <attributeEditorField index="4" showLabel="1" horizontalStretch="0" verticalStretch="0" name="proc_parz">
-          <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+        <attributeEditorField horizontalStretch="0" verticalStretch="0" index="4" showLabel="1" name="proc_parz">
+          <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+            <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0" bold="0" strikethrough="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField index="0" showLabel="1" horizontalStretch="0" verticalStretch="0" name="fid">
-          <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+        <attributeEditorField horizontalStretch="0" verticalStretch="0" index="0" showLabel="1" name="fid">
+          <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+            <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0" bold="0" strikethrough="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField index="5" showLabel="1" horizontalStretch="0" verticalStretch="0" name="lunghezza">
-          <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-            <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+        <attributeEditorField horizontalStretch="0" verticalStretch="0" index="5" showLabel="1" name="lunghezza">
+          <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+            <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0" bold="0" strikethrough="0"/>
           </labelStyle>
         </attributeEditorField>
       </attributeEditorContainer>
@@ -770,15 +853,16 @@ def my_form_open(dialog, layer, feature):
     <field labelOnTop="0" name="proc_parz"/>
   </labelOnTop>
   <reuseLastValue>
-    <field reuseLastValue="0" name="fid"/>
-    <field reuseLastValue="0" name="fonte_proc"/>
-    <field reuseLastValue="0" name="lunghezza"/>
-    <field reuseLastValue="0" name="osservazioni"/>
-    <field reuseLastValue="0" name="prob_propagazione"/>
-    <field reuseLastValue="0" name="prob_rottura"/>
-    <field reuseLastValue="0" name="proc_parz"/>
+    <field name="fid" reuseLastValue="0"/>
+    <field name="fonte_proc" reuseLastValue="0"/>
+    <field name="lunghezza" reuseLastValue="0"/>
+    <field name="osservazioni" reuseLastValue="0"/>
+    <field name="prob_propagazione" reuseLastValue="0"/>
+    <field name="prob_rottura" reuseLastValue="0"/>
+    <field name="proc_parz" reuseLastValue="0"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
+  <previewExpression>"fid"</previewExpression>
   <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/pzp/qml/propagation.qml
+++ b/pzp/qml/propagation.qml
@@ -1,338 +1,454 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Symbology|Fields|Forms" version="3.16.16-Hannover">
-  <renderer-v2 attr="prob_propagazione" type="categorizedSymbol" forceraster="0" symbollevels="0" enableorderby="0">
+<qgis styleCategories="Symbology|Fields|Forms" version="3.43.0-Master">
+  <renderer-v2 enableorderby="0" attr="prob_propagazione" type="categorizedSymbol" symbollevels="0" referencescale="-1" forceraster="0">
     <categories>
-      <category value="1003" label="alta" render="true" symbol="0"/>
-      <category value="1002" label="media" render="true" symbol="1"/>
-      <category value="1001" label="bassa" render="true" symbol="2"/>
-      <category value="" label="" render="true" symbol="3"/>
+      <category label="alta" uuid="0" type="string" value="1003" symbol="0" render="true"/>
+      <category label="media" uuid="1" type="string" value="1002" symbol="1" render="true"/>
+      <category label="bassa" uuid="2" type="string" value="1001" symbol="2" render="true"/>
+      <category label="" uuid="3" type="string" value="" symbol="3" render="false"/>
     </categories>
     <symbols>
-      <symbol alpha="1" name="0" force_rhr="0" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" enabled="1" locked="0" pass="0">
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="square" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="35,35,35,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.26" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" locked="0" pass="0" id="{a2791384-74e0-4a62-868a-88575f8e3b9b}" class="SimpleLine">
+          <Option type="Map">
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="square" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="227,26,28,255,rgb:0.8901960784313725,0.10196078431372549,0.10980392156862745,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.26" name="line_width"/>
+            <Option type="QString" value="MM" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="MarkerLine" enabled="1" locked="0" pass="0">
-          <prop v="4" k="average_angle_length"/>
-          <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale"/>
-          <prop v="MM" k="average_angle_unit"/>
-          <prop v="20" k="interval"/>
-          <prop v="3x:0,0,0,0,0,0" k="interval_map_unit_scale"/>
-          <prop v="Point" k="interval_unit"/>
-          <prop v="-0.6" k="offset"/>
-          <prop v="0.5" k="offset_along_line"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-          <prop v="Point" k="offset_along_line_unit"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="interval" k="placement"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="1" k="rotate"/>
+        <layer enabled="1" locked="0" pass="0" id="{0780e612-1b38-4295-b40e-d59c11913cca}" class="MarkerLine">
+          <Option type="Map">
+            <Option type="QString" value="4" name="average_angle_length"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="average_angle_map_unit_scale"/>
+            <Option type="QString" value="MM" name="average_angle_unit"/>
+            <Option type="QString" value="20" name="interval"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="interval_map_unit_scale"/>
+            <Option type="QString" value="Point" name="interval_unit"/>
+            <Option type="QString" value="-0.6" name="offset"/>
+            <Option type="QString" value="0.5" name="offset_along_line"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_along_line_map_unit_scale"/>
+            <Option type="QString" value="Point" name="offset_along_line_unit"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="bool" value="true" name="place_on_every_part"/>
+            <Option type="QString" value="Interval" name="placements"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="1" name="rotate"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol alpha="1" name="@0@1" force_rhr="0" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
-              <prop v="0" k="angle"/>
-              <prop v="0,0,0,255" k="color"/>
-              <prop v="1" k="horizontal_anchor_point"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="equilateral_triangle" k="name"/>
-              <prop v="4.40000000000000036,4.40000000000000036" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="Point" k="offset_unit"/>
-              <prop v="255,255,255,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0" k="outline_width"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="area" k="scale_method"/>
-              <prop v="10" k="size"/>
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-              <prop v="Pixel" k="size_unit"/>
-              <prop v="1" k="vertical_anchor_point"/>
+          <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="marker" force_rhr="0" name="@0@1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" locked="0" pass="0" id="{2d747dd0-d5d1-422d-8d8d-bce1270a9abd}" class="SimpleMarker">
+              <Option type="Map">
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="equilateral_triangle" name="name"/>
+                <Option type="QString" value="4.40000000000000036,4.40000000000000036" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="Point" name="offset_unit"/>
+                <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="area" name="scale_method"/>
+                <Option type="QString" value="10" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="Pixel" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
+              </Option>
               <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
-                  <prop v="0" k="blend_mode"/>
-                  <prop v="2" k="draw_mode"/>
-                  <prop v="1" k="enabled"/>
-                  <prop v="1" k="opacity"/>
+                  <Option type="Map">
+                    <Option type="QString" value="0" name="blend_mode"/>
+                    <Option type="QString" value="2" name="draw_mode"/>
+                    <Option type="QString" value="1" name="enabled"/>
+                    <Option type="QString" value="1" name="opacity"/>
+                  </Option>
                 </effect>
               </effect>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol alpha="1" name="1" force_rhr="0" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" enabled="1" locked="0" pass="0">
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="square" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="35,35,35,255" k="line_color"/>
-          <prop v="dash" k="line_style"/>
-          <prop v="1.08" k="line_width"/>
-          <prop v="Point" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="Point" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" locked="0" pass="0" id="{1570a05b-798d-4f86-84ee-299d3e67dbce}" class="SimpleLine">
+          <Option type="Map">
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="square" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="255,127,0,255,rgb:1,0.49803921568627452,0,1" name="line_color"/>
+            <Option type="QString" value="dash" name="line_style"/>
+            <Option type="QString" value="1.08" name="line_width"/>
+            <Option type="QString" value="Point" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="Point" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="MarkerLine" enabled="1" locked="0" pass="0">
-          <prop v="4" k="average_angle_length"/>
-          <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale"/>
-          <prop v="MM" k="average_angle_unit"/>
-          <prop v="20" k="interval"/>
-          <prop v="3x:0,0,0,0,0,0" k="interval_map_unit_scale"/>
-          <prop v="Point" k="interval_unit"/>
-          <prop v="-0.6" k="offset"/>
-          <prop v="0.5" k="offset_along_line"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-          <prop v="Point" k="offset_along_line_unit"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="Point" k="offset_unit"/>
-          <prop v="interval" k="placement"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="1" k="rotate"/>
+        <layer enabled="1" locked="0" pass="0" id="{46ebdb28-028d-406d-8ca8-032d55f1045e}" class="MarkerLine">
+          <Option type="Map">
+            <Option type="QString" value="4" name="average_angle_length"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="average_angle_map_unit_scale"/>
+            <Option type="QString" value="MM" name="average_angle_unit"/>
+            <Option type="QString" value="20" name="interval"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="interval_map_unit_scale"/>
+            <Option type="QString" value="Point" name="interval_unit"/>
+            <Option type="QString" value="-0.6" name="offset"/>
+            <Option type="QString" value="0.5" name="offset_along_line"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_along_line_map_unit_scale"/>
+            <Option type="QString" value="Point" name="offset_along_line_unit"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="Point" name="offset_unit"/>
+            <Option type="bool" value="true" name="place_on_every_part"/>
+            <Option type="QString" value="Interval" name="placements"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="1" name="rotate"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol alpha="1" name="@1@1" force_rhr="0" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
-              <prop v="0" k="angle"/>
-              <prop v="0,0,0,255" k="color"/>
-              <prop v="1" k="horizontal_anchor_point"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="equilateral_triangle" k="name"/>
-              <prop v="4.40000000000000036,4.40000000000000036" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="Point" k="offset_unit"/>
-              <prop v="255,255,255,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0" k="outline_width"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="diameter" k="scale_method"/>
-              <prop v="10" k="size"/>
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-              <prop v="Pixel" k="size_unit"/>
-              <prop v="1" k="vertical_anchor_point"/>
+          <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="marker" force_rhr="0" name="@1@1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" locked="0" pass="0" id="{11d2cf12-bb1d-4943-9f61-cdea4c34c49a}" class="SimpleMarker">
+              <Option type="Map">
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="equilateral_triangle" name="name"/>
+                <Option type="QString" value="4.40000000000000036,4.40000000000000036" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="Point" name="offset_unit"/>
+                <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="10" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="Pixel" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol alpha="1" name="2" force_rhr="0" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" enabled="1" locked="0" pass="0">
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="square" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="35,35,35,255" k="line_color"/>
-          <prop v="dot" k="line_style"/>
-          <prop v="1.08" k="line_width"/>
-          <prop v="Point" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="2">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" locked="0" pass="0" id="{a1c724e9-0289-481e-ac21-f3fc86225f70}" class="SimpleLine">
+          <Option type="Map">
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="square" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="line_color"/>
+            <Option type="QString" value="dot" name="line_style"/>
+            <Option type="QString" value="1.08" name="line_width"/>
+            <Option type="QString" value="Point" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="MarkerLine" enabled="1" locked="0" pass="0">
-          <prop v="4" k="average_angle_length"/>
-          <prop v="3x:0,0,0,0,0,0" k="average_angle_map_unit_scale"/>
-          <prop v="MM" k="average_angle_unit"/>
-          <prop v="20" k="interval"/>
-          <prop v="3x:0,0,0,0,0,0" k="interval_map_unit_scale"/>
-          <prop v="Point" k="interval_unit"/>
-          <prop v="-0.6" k="offset"/>
-          <prop v="0.5" k="offset_along_line"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-          <prop v="Point" k="offset_along_line_unit"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="Point" k="offset_unit"/>
-          <prop v="interval" k="placement"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="1" k="rotate"/>
+        <layer enabled="1" locked="0" pass="0" id="{71305106-e631-4c6e-b111-8a6b4780542d}" class="MarkerLine">
+          <Option type="Map">
+            <Option type="QString" value="4" name="average_angle_length"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="average_angle_map_unit_scale"/>
+            <Option type="QString" value="MM" name="average_angle_unit"/>
+            <Option type="QString" value="20" name="interval"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="interval_map_unit_scale"/>
+            <Option type="QString" value="Point" name="interval_unit"/>
+            <Option type="QString" value="-0.6" name="offset"/>
+            <Option type="QString" value="0.5" name="offset_along_line"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_along_line_map_unit_scale"/>
+            <Option type="QString" value="Point" name="offset_along_line_unit"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="Point" name="offset_unit"/>
+            <Option type="bool" value="true" name="place_on_every_part"/>
+            <Option type="QString" value="Interval" name="placements"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="1" name="rotate"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol alpha="1" name="@2@1" force_rhr="0" type="marker" clip_to_extent="1">
-            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
-              <prop v="0" k="angle"/>
-              <prop v="0,0,0,255" k="color"/>
-              <prop v="1" k="horizontal_anchor_point"/>
-              <prop v="bevel" k="joinstyle"/>
-              <prop v="equilateral_triangle" k="name"/>
-              <prop v="4.40000000000000036,4.40000000000000036" k="offset"/>
-              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-              <prop v="Point" k="offset_unit"/>
-              <prop v="255,255,255,255" k="outline_color"/>
-              <prop v="solid" k="outline_style"/>
-              <prop v="0" k="outline_width"/>
-              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-              <prop v="MM" k="outline_width_unit"/>
-              <prop v="diameter" k="scale_method"/>
-              <prop v="10" k="size"/>
-              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-              <prop v="Point" k="size_unit"/>
-              <prop v="1" k="vertical_anchor_point"/>
+          <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="marker" force_rhr="0" name="@2@1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" locked="0" pass="0" id="{16f6e03c-63c4-4eb2-9ea8-3b448ef38d88}" class="SimpleMarker">
+              <Option type="Map">
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="equilateral_triangle" name="name"/>
+                <Option type="QString" value="4.40000000000000036,4.40000000000000036" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="Point" name="offset_unit"/>
+                <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="10" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="Point" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
       </symbol>
-      <symbol alpha="1" name="3" force_rhr="0" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" enabled="1" locked="0" pass="0">
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="square" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="63,52,215,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.26" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="3">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" locked="0" pass="0" id="{48d18e69-644a-468d-894a-16eca28a21de}" class="SimpleLine">
+          <Option type="Map">
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="square" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="63,52,215,255,rgb:0.24705882352941178,0.20392156862745098,0.84313725490196079,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.26" name="line_width"/>
+            <Option type="QString" value="MM" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <source-symbol>
-      <symbol alpha="1" name="0" force_rhr="0" type="line" clip_to_extent="1">
-        <layer class="SimpleLine" enabled="1" locked="0" pass="0">
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="square" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="35,35,35,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.26" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" locked="0" pass="0" id="{9ae01466-4608-4766-94c0-b24ba15276f7}" class="SimpleLine">
+          <Option type="Map">
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="square" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.26" name="line_width"/>
+            <Option type="QString" value="MM" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" value="" type="QString"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option name="type" value="collection" type="QString"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -340,151 +456,328 @@
     </source-symbol>
     <rotation/>
     <sizescale/>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" locked="0" pass="0" id="{d5117ecb-cdb1-45f7-a06f-c78c342e2626}" class="SimpleLine">
+          <Option type="Map">
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="square" name="capstyle"/>
+            <Option type="QString" value="5;2" name="customdash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="0.26" name="line_width"/>
+            <Option type="QString" value="MM" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field configurationFlags="None" name="fid">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="osservazioni">
+    <field configurationFlags="NoFlag" name="fid">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="prob_propagazione">
+    <field configurationFlags="NoFlag" name="prob_propagazione">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="bassa" value="1001" type="QString"/>
+                <Option type="QString" value="1001" name="bassa"/>
               </Option>
               <Option type="Map">
-                <Option name="media" value="1002" type="QString"/>
+                <Option type="QString" value="1002" name="media"/>
               </Option>
               <Option type="Map">
-                <Option name="alta" value="1003" type="QString"/>
+                <Option type="QString" value="1003" name="alta"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>"/>
               </Option>
             </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="fonte_proc">
-      <editWidget type="TextEdit">
+    <field configurationFlags="NoFlag" name="fonte_proc">
+      <editWidget type="ValueRelation">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="QString" value="Case&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 0 then 'Sconosciuto'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1001 then 'Scenario puntuale'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1000 then 'Scenario diffuso'&#xd;&#xa;&#x9;else '_'&#xd;&#xa;End" name="Description"/>
+            <Option type="invalid" name="FilterExpression"/>
+            <Option type="QString" value="fonte_proc" name="Key"/>
+            <Option type="QString" value="Zone_instabilita_1ed06e0b_ac25_48cb_a1ae_d42c8a2f4097" name="Layer"/>
+            <Option type="QString" value="Zona sorgente (fonte processo)" name="LayerName"/>
+            <Option type="QString" value="ogr" name="LayerProviderName"/>
+            <Option type="QString" value="F:/UPIP/06_StrumentiGis/02_Progetti base/09_Plugin QGIS/01_Test QGIS/Mod.proc.CadutaSassi2024/data_3000_19092023_145610.gpkg|layername=Zone_instabilita" name="LayerSource"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="fonte_proc" name="Value"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="prob_rottura">
+    <field configurationFlags="NoFlag" name="prob_rottura">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option name="map" type="List">
+            <Option type="List" name="map">
               <Option type="Map">
-                <Option name="molto bassa" value="1000" type="QString"/>
+                <Option type="QString" value="1000" name="molto bassa"/>
               </Option>
               <Option type="Map">
-                <Option name="bassa" value="1001" type="QString"/>
+                <Option type="QString" value="1001" name="bassa"/>
               </Option>
               <Option type="Map">
-                <Option name="media" value="1002" type="QString"/>
+                <Option type="QString" value="1002" name="media"/>
               </Option>
               <Option type="Map">
-                <Option name="alta" value="1003" type="QString"/>
+                <Option type="QString" value="1003" name="alta"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>"/>
               </Option>
             </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="NoFlag" name="proc_parz">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="3000" name="caduta sassi o blocchi"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="3001" name="crollo di roccia o frana"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="NoFlag" name="lunghezza">
+      <editWidget type="Range">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="AllowNull"/>
+            <Option type="double" value="1.7976931348623157e+308" name="Max"/>
+            <Option type="double" value="-1.7976931348623157e+308" name="Min"/>
+            <Option type="int" value="1" name="Precision"/>
+            <Option type="double" value="1" name="Step"/>
+            <Option type="QString" value="SpinBox" name="Style"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" name="" field="fid"/>
-    <alias index="1" name="Osservazioni" field="osservazioni"/>
-    <alias index="2" name="Probabilità propagazione" field="prob_propagazione"/>
-    <alias index="3" name="Fonte del processo (es. nome riale)" field="fonte_proc"/>
-    <alias index="4" name="Probabilità di rottura" field="prob_rottura"/>
+    <alias index="0" field="fid" name="Identificativo (automatico)"/>
+    <alias index="1" field="prob_propagazione" name="Limite probabilità di propagazione"/>
+    <alias index="2" field="fonte_proc" name="Zona sorgente (fonte processo)"/>
+    <alias index="3" field="prob_rottura" name="Probabilità di rottura (scenario)"/>
+    <alias index="4" field="proc_parz" name="Processo rappresentato TI"/>
+    <alias index="5" field="lunghezza" name="Lunghezza in metri"/>
   </aliases>
+  <splitPolicies>
+    <policy field="fid" policy="Duplicate"/>
+    <policy field="prob_propagazione" policy="Duplicate"/>
+    <policy field="fonte_proc" policy="Duplicate"/>
+    <policy field="prob_rottura" policy="Duplicate"/>
+    <policy field="proc_parz" policy="Duplicate"/>
+    <policy field="lunghezza" policy="Duplicate"/>
+  </splitPolicies>
+  <duplicatePolicies>
+    <policy field="fid" policy="Duplicate"/>
+    <policy field="prob_propagazione" policy="Duplicate"/>
+    <policy field="fonte_proc" policy="Duplicate"/>
+    <policy field="prob_rottura" policy="Duplicate"/>
+    <policy field="proc_parz" policy="Duplicate"/>
+    <policy field="lunghezza" policy="Duplicate"/>
+  </duplicatePolicies>
   <defaults>
-    <default applyOnUpdate="0" field="fid" expression=""/>
-    <default applyOnUpdate="0" field="osservazioni" expression=""/>
-    <default applyOnUpdate="0" field="prob_propagazione" expression=""/>
-    <default applyOnUpdate="0" field="fonte_proc" expression=""/>
-    <default applyOnUpdate="0" field="prob_rottura" expression=""/>
+    <default expression="" field="fid" applyOnUpdate="0"/>
+    <default expression="" field="prob_propagazione" applyOnUpdate="0"/>
+    <default expression="" field="fonte_proc" applyOnUpdate="0"/>
+    <default expression="" field="prob_rottura" applyOnUpdate="0"/>
+    <default expression=" @pzp_process" field="proc_parz" applyOnUpdate="0"/>
+    <default expression="" field="lunghezza" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint constraints="3" field="fid" unique_strength="1" notnull_strength="1" exp_strength="0"/>
-    <constraint constraints="0" field="osservazioni" unique_strength="0" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" field="prob_propagazione" unique_strength="0" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="7" field="fonte_proc" unique_strength="1" notnull_strength="1" exp_strength="1"/>
-    <constraint constraints="0" field="prob_rottura" unique_strength="0" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="1" exp_strength="0" constraints="3" field="fid" notnull_strength="1"/>
+    <constraint unique_strength="0" exp_strength="0" constraints="0" field="prob_propagazione" notnull_strength="0"/>
+    <constraint unique_strength="0" exp_strength="0" constraints="0" field="fonte_proc" notnull_strength="0"/>
+    <constraint unique_strength="0" exp_strength="0" constraints="0" field="prob_rottura" notnull_strength="0"/>
+    <constraint unique_strength="0" exp_strength="0" constraints="0" field="proc_parz" notnull_strength="0"/>
+    <constraint unique_strength="0" exp_strength="0" constraints="0" field="lunghezza" notnull_strength="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" desc="" field="fid"/>
-    <constraint exp="" desc="" field="osservazioni"/>
     <constraint exp="" desc="" field="prob_propagazione"/>
     <constraint exp="" desc="" field="fonte_proc"/>
     <constraint exp="" desc="" field="prob_rottura"/>
+    <constraint exp="" desc="" field="proc_parz"/>
+    <constraint exp="" desc="" field="lunghezza"/>
   </constraintExpressions>
-  <expressionfields/>
+  <expressionfields>
+    <field precision="0" comment="" expression=" $length " subType="0" typeName="double precision" type="6" length="-1" name="lunghezza"/>
+  </expressionfields>
   <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
   <editforminitfilepath></editforminitfilepath>
   <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
-QGIS forms can have a Python function that is called when the form is
-opened.
+I moduli QGIS possono avere una funzione Python che può essere chiamata quando viene aperto un modulo.
 
-Use this function to add extra logic to your forms.
+Usa questa funzione per aggiungere logica extra ai tuoi moduli.
 
-Enter the name of the function in the "Python Init function"
-field.
-An example follows:
+Inserisci il nome della funzione nel campo "Funzione Python di avvio".
+
+Segue un esempio:
 """
 from qgis.PyQt.QtWidgets import QWidget
 
 def my_form_open(dialog, layer, feature):
-    geom = feature.geometry()
-    control = dialog.findChild(QWidget, "MyLineEdit")
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
-  <featformsuppress>0</featformsuppress>
+  <featformsuppress>2</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField index="1" name="osservazioni" showLabel="1"/>
-    <attributeEditorField index="2" name="prob_propagazione" showLabel="1"/>
-    <attributeEditorField index="3" name="fonte_proc" showLabel="1"/>
-    <attributeEditorField index="4" name="prob_rottura" showLabel="1"/>
+    <labelStyle labelColor="" overrideLabelFont="0" overrideLabelColor="0">
+      <labelFont bold="0" strikethrough="0" description="Ubuntu Sans,11,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+    </labelStyle>
+    <attributeEditorContainer collapsedExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" horizontalStretch="0" collapsed="0" verticalStretch="0" visibilityExpressionEnabled="0" columnCount="1" type="Tab" name="Attributi" collapsedExpression="">
+      <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+        <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+      </labelStyle>
+      <attributeEditorField index="1" showLabel="1" horizontalStretch="0" verticalStretch="0" name="prob_propagazione">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+          <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorField index="3" showLabel="1" horizontalStretch="0" verticalStretch="0" name="prob_rottura">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+          <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorField index="2" showLabel="1" horizontalStretch="0" verticalStretch="0" name="fonte_proc">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+          <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorContainer collapsedExpressionEnabled="0" groupBox="1" visibilityExpression="" showLabel="1" horizontalStretch="0" collapsed="0" verticalStretch="0" visibilityExpressionEnabled="0" columnCount="1" type="GroupBox" name="Automatici" collapsedExpression="">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+          <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+        </labelStyle>
+        <attributeEditorField index="4" showLabel="1" horizontalStretch="0" verticalStretch="0" name="proc_parz">
+          <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+            <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+          </labelStyle>
+        </attributeEditorField>
+        <attributeEditorField index="0" showLabel="1" horizontalStretch="0" verticalStretch="0" name="fid">
+          <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+            <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+          </labelStyle>
+        </attributeEditorField>
+        <attributeEditorField index="5" showLabel="1" horizontalStretch="0" verticalStretch="0" name="lunghezza">
+          <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+            <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+          </labelStyle>
+        </attributeEditorField>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field name="fid" editable="1"/>
-    <field name="fonte_proc" editable="1"/>
-    <field name="osservazioni" editable="1"/>
-    <field name="prob_propagazione" editable="1"/>
-    <field name="prob_rottura" editable="1"/>
+    <field editable="1" name="fid"/>
+    <field editable="1" name="fonte_proc"/>
+    <field editable="0" name="lunghezza"/>
+    <field editable="1" name="osservazioni"/>
+    <field editable="1" name="periodo_ritorno"/>
+    <field editable="1" name="prob_propagazione"/>
+    <field editable="1" name="prob_rottura"/>
+    <field editable="1" name="proc_parz"/>
   </editable>
   <labelOnTop>
-    <field name="fid" labelOnTop="0"/>
-    <field name="fonte_proc" labelOnTop="0"/>
-    <field name="osservazioni" labelOnTop="0"/>
-    <field name="prob_propagazione" labelOnTop="0"/>
-    <field name="prob_rottura" labelOnTop="0"/>
+    <field labelOnTop="0" name="fid"/>
+    <field labelOnTop="0" name="fonte_proc"/>
+    <field labelOnTop="0" name="lunghezza"/>
+    <field labelOnTop="1" name="osservazioni"/>
+    <field labelOnTop="0" name="periodo_ritorno"/>
+    <field labelOnTop="0" name="prob_propagazione"/>
+    <field labelOnTop="0" name="prob_rottura"/>
+    <field labelOnTop="0" name="proc_parz"/>
   </labelOnTop>
+  <reuseLastValue>
+    <field reuseLastValue="0" name="fid"/>
+    <field reuseLastValue="0" name="fonte_proc"/>
+    <field reuseLastValue="0" name="lunghezza"/>
+    <field reuseLastValue="0" name="osservazioni"/>
+    <field reuseLastValue="0" name="prob_propagazione"/>
+    <field reuseLastValue="0" name="prob_rottura"/>
+    <field reuseLastValue="0" name="proc_parz"/>
+  </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
   <layerGeometryType>1</layerGeometryType>

--- a/pzp/qml/source_zones.qml
+++ b/pzp/qml/source_zones.qml
@@ -1,0 +1,445 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="LayerConfiguration|Symbology|Labeling|Fields|Forms" version="3.43.0-Master" labelsEnabled="1" readOnly="0">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <renderer-v2 enableorderby="0" type="singleSymbol" symbollevels="0" referencescale="-1" forceraster="0">
+    <symbols>
+      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="fill" force_rhr="0" name="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" locked="0" pass="0" id="{f2cc1fde-9585-49b2-a0d1-d01801f5c05a}" class="LinePatternFill">
+          <Option type="Map">
+            <Option type="QString" value="45" name="angle"/>
+            <Option type="QString" value="during_render" name="clip_mode"/>
+            <Option type="QString" value="121,125,127,201,rgb:0.47450980392156861,0.49019607843137253,0.49803921568627452,0.78823529411764703" name="color"/>
+            <Option type="QString" value="feature" name="coordinate_reference"/>
+            <Option type="QString" value="2.2" name="distance"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="distance_map_unit_scale"/>
+            <Option type="QString" value="MM" name="distance_unit"/>
+            <Option type="QString" value="1" name="line_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="line_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+          <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="line" force_rhr="0" name="@0@0">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" locked="0" pass="0" id="{5983318c-7328-48ba-9202-da32e09c7ae2}" class="SimpleLine">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="121,125,127,201,rgb:0.47450980392156861,0.49019607843137253,0.49803921568627452,0.78823529411764703" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.2" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </layer>
+        <layer enabled="1" locked="0" pass="0" id="{9ed8d944-154f-4a38-92a3-00543fd61322}" class="SimpleFill">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,0,255,0,rgb:0,0,1,0" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="0,0,1,255,rgb:0,0,0.00392156862745098,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.26" name="outline_width"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </data-defined-properties>
+  </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="fill" force_rhr="0" name="">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" locked="0" pass="0" id="{e47ac32f-1a69-4193-883a-0e38f12fb5fb}" class="SimpleFill">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,0,255,255,rgb:0,0,1,1" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.26" name="outline_width"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style textOrientation="horizontal" tabStopDistanceUnit="Point" fontSizeUnit="Point" fontWordSpacing="0" legendString="Aa" fontSize="10" multilineHeightUnit="Percentage" blendMode="0" textColor="50,50,50,255,rgb:0.19607843137254902,0.19607843137254902,0.19607843137254902,1" multilineHeight="1" fontItalic="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontSizeMapUnitScale="3x:0,0,0,0,0,0" isExpression="0" allowHtml="0" fieldName="fonte_proc" capitalization="0" fontKerning="1" fontFamily="Open Sans" fontLetterSpacing="0" tabStopDistance="80" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedItalic="0" namedStyle="Regular" textOpacity="1" fontUnderline="0" fontWeight="75" useSubstitutions="0" forcedBold="0" fontStrikeout="0">
+        <families/>
+        <text-buffer bufferOpacity="1" bufferDraw="0" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferBlendMode="0" bufferSizeUnits="MM" bufferColor="250,250,250,255,rgb:0.98039215686274506,0.98039215686274506,0.98039215686274506,1" bufferNoFill="1" bufferJoinStyle="128"/>
+        <text-mask maskSize="1.5" maskSize2="1.5" maskSizeUnits="MM" maskEnabled="0" maskType="0" maskOpacity="1" maskJoinStyle="128" maskedSymbolLayers="" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+        <background shapeDraw="0" shapeOffsetY="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeRadiiY="0" shapeBorderWidthUnit="Point" shapeSizeType="0" shapeSizeUnit="Point" shapeRadiiUnit="Point" shapeJoinStyle="64" shapeBorderWidth="0" shapeSizeX="0" shapeSizeY="0" shapeRadiiX="0" shapeType="0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="Point" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeOffsetX="0" shapeSVGFile="" shapeBlendMode="0" shapeRotation="0">
+          <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="marker" force_rhr="0" name="markerSymbol">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" locked="0" pass="0" id="" class="SimpleMarker">
+              <Option type="Map">
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="213,180,60,255,rgb:0.83529411764705885,0.70588235294117652,0.23529411764705882,1" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="circle" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="2" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MM" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+          <symbol alpha="1" is_animated="0" frame_rate="10" clip_to_extent="1" type="fill" force_rhr="0" name="fillSymbol">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" locked="0" pass="0" id="" class="SimpleFill">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                <Option type="QString" value="no" name="outline_style"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="Point" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowDraw="0" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowOffsetDist="1" shadowOffsetAngle="135" shadowRadius="1.5" shadowRadiusUnit="MM" shadowRadiusAlphaOnly="0" shadowUnder="0" shadowOffsetUnit="MM" shadowOffsetGlobal="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowBlendMode="6" shadowScale="100"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format multilineAlign="3" reverseDirectionSymbol="0" wrapChar="" plussign="0" useMaxLineLengthForAutoWrap="1" leftDirectionSymbol="&lt;" formatNumbers="0" decimals="3" rightDirectionSymbol=">" placeDirectionSymbol="0" addDirectionSymbol="0" autoWrapLength="0"/>
+      <placement repeatDistance="0" lineAnchorPercent="0.5" placement="0" offsetType="0" lineAnchorType="0" geometryGeneratorType="PointGeometry" overrunDistance="0" geometryGeneratorEnabled="0" centroidWhole="0" maxCurvedCharAngleOut="-25" layerType="PolygonGeometry" repeatDistanceUnits="MM" priority="5" yOffset="0" placementFlags="10" xOffset="0" maximumDistanceUnit="MM" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" offsetUnits="MM" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" distUnits="MM" overrunDistanceUnit="MM" lineAnchorClipping="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" dist="0" polygonPlacementFlags="2" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" rotationUnit="AngleDegrees" prioritization="PreferCloser" geometryGenerator="" lineAnchorTextPoint="FollowPlacement" overlapHandling="PreventOverlap" maximumDistance="0" fitInPolygonOnly="0" preserveRotation="1" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="0" maxCurvedCharAngleIn="25" rotationAngle="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" centroidInside="0"/>
+      <rendering maxNumLabels="2000" minFeatureSize="0" scaleVisibility="0" fontLimitPixelSize="0" mergeLines="0" obstacleFactor="1" scaleMax="0" labelPerPart="0" obstacle="1" upsidedownLabels="0" limitNumLabels="0" fontMinPixelSize="3" zIndex="0" drawLabels="1" unplacedVisibility="0" fontMaxPixelSize="10000" scaleMin="0" obstacleType="1"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option name="properties"/>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+          <Option type="int" value="0" name="blendMode"/>
+          <Option type="Map" name="ddProperties">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+          <Option type="bool" value="false" name="drawToAllParts"/>
+          <Option type="QString" value="0" name="enabled"/>
+          <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+          <Option type="QString" value="&lt;symbol alpha=&quot;1&quot; is_animated=&quot;0&quot; frame_rate=&quot;10&quot; clip_to_extent=&quot;1&quot; type=&quot;line&quot; force_rhr=&quot;0&quot; name=&quot;symbol&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer enabled=&quot;1&quot; locked=&quot;0&quot; pass=&quot;0&quot; id=&quot;{14404a15-e2c9-46a7-95cb-fcacde60e09c}&quot; class=&quot;SimpleLine&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+          <Option type="double" value="0" name="minLength"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+          <Option type="QString" value="MM" name="minLengthUnit"/>
+          <Option type="double" value="0" name="offsetFromAnchor"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+          <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+          <Option type="double" value="0" name="offsetFromLabel"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+          <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <fieldConfiguration>
+    <field configurationFlags="NoFlag" name="fid">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="NoFlag" name="commento">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="NoFlag" name="fonte_proc">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="NoFlag" name="scenario">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="1000" name="Diffuso"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1001" name="Puntuale"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" field="fid" name=""/>
+    <alias index="1" field="commento" name="Osservazioni"/>
+    <alias index="2" field="fonte_proc" name="Settore/i (fonte processo)"/>
+    <alias index="3" field="scenario" name="Scenario"/>
+  </aliases>
+  <splitPolicies>
+    <policy field="fid" policy="Duplicate"/>
+    <policy field="commento" policy="Duplicate"/>
+    <policy field="fonte_proc" policy="Duplicate"/>
+    <policy field="scenario" policy="Duplicate"/>
+  </splitPolicies>
+  <duplicatePolicies>
+    <policy field="fid" policy="Duplicate"/>
+    <policy field="commento" policy="Duplicate"/>
+    <policy field="fonte_proc" policy="Duplicate"/>
+    <policy field="scenario" policy="Duplicate"/>
+  </duplicatePolicies>
+  <defaults>
+    <default expression="" field="fid" applyOnUpdate="0"/>
+    <default expression="" field="commento" applyOnUpdate="0"/>
+    <default expression="" field="fonte_proc" applyOnUpdate="0"/>
+    <default expression="" field="scenario" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" exp_strength="0" constraints="3" field="fid" notnull_strength="1"/>
+    <constraint unique_strength="0" exp_strength="0" constraints="0" field="commento" notnull_strength="0"/>
+    <constraint unique_strength="0" exp_strength="0" constraints="0" field="fonte_proc" notnull_strength="0"/>
+    <constraint unique_strength="0" exp_strength="0" constraints="0" field="scenario" notnull_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" desc="" field="fid"/>
+    <constraint exp="" desc="" field="commento"/>
+    <constraint exp="" desc="" field="fonte_proc"/>
+    <constraint exp="" desc="" field="scenario"/>
+  </constraintExpressions>
+  <expressionfields/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+I moduli di QGIS possono avere una funzione Python che può essere chiamata quando un modulo viene aperto.
+
+Usa questa funzione per aggiungere logica extra ai tuoi moduli.
+
+Inserisci il nome della funzione nel campo "Funzione Python di avvio".
+
+Segue un esempio:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+geom = feature.geometry()
+control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <labelStyle labelColor="" overrideLabelFont="0" overrideLabelColor="0">
+      <labelFont bold="0" strikethrough="0" description="Ubuntu Sans,11,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+    </labelStyle>
+    <attributeEditorContainer collapsedExpressionEnabled="0" groupBox="0" visibilityExpression="" showLabel="1" horizontalStretch="0" collapsed="0" verticalStretch="0" visibilityExpressionEnabled="0" columnCount="1" type="Tab" name="Attributi" collapsedExpression="">
+      <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+        <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+      </labelStyle>
+      <attributeEditorField index="3" showLabel="1" horizontalStretch="0" verticalStretch="0" name="scenario">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+          <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorField index="2" showLabel="1" horizontalStretch="0" verticalStretch="0" name="fonte_proc">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+          <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorField index="1" showLabel="1" horizontalStretch="0" verticalStretch="0" name="commento">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+          <labelFont bold="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" underline="0" italic="0"/>
+        </labelStyle>
+      </attributeEditorField>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="commento"/>
+    <field editable="1" name="fid"/>
+    <field editable="1" name="fonte_proc"/>
+    <field editable="1" name="proc_parz"/>
+    <field editable="1" name="scenario"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="commento"/>
+    <field labelOnTop="0" name="fid"/>
+    <field labelOnTop="0" name="fonte_proc"/>
+    <field labelOnTop="0" name="proc_parz"/>
+    <field labelOnTop="0" name="scenario"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field reuseLastValue="0" name="commento"/>
+    <field reuseLastValue="0" name="fid"/>
+    <field reuseLastValue="0" name="fonte_proc"/>
+    <field reuseLastValue="0" name="proc_parz"/>
+    <field reuseLastValue="0" name="scenario"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>"commento"</previewExpression>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/pzp/utils/utils.py
+++ b/pzp/utils/utils.py
@@ -369,7 +369,7 @@ def load_gpkg_layer(layer_name, gpkg_path):
     return layer
 
 
-def set_value_relation_field(layer, field_name, other_layer, key_field, value_field):
+def set_value_relation_field(layer, field_name, other_layer, key_field, value_field, description=""):
     widget = QgsEditorWidgetSetup(
         "ValueRelation",
         {
@@ -381,6 +381,7 @@ def set_value_relation_field(layer, field_name, other_layer, key_field, value_fi
             "OrderByValue": False,
             "UseCompleter": False,
             "Value": value_field,
+            "Description": description,
         },
     )
 

--- a/pzp/utils/utils.py
+++ b/pzp/utils/utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from qgis import processing
 from qgis.core import (
     Qgis,
+    QgsCategorizedSymbolRenderer,
     QgsCoordinateReferenceSystem,
     QgsDefaultValue,
     QgsEditorWidgetSetup,
@@ -317,6 +318,22 @@ def set_qml_style(layer, qml_name):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     qml_file_path = os.path.join(current_dir, "../qml", f"{qml_name}.qml")
     layer.loadNamedStyle(qml_file_path)
+
+
+def remove_renderer_category(layer: QgsVectorLayer, category_value: str) -> bool:
+    renderer = layer.renderer()
+    res = False
+
+    if isinstance(layer.renderer(), QgsCategorizedSymbolRenderer):
+        index = renderer.categoryIndexForValue(category_value)
+
+        if index != -1:
+            res = renderer.deleteCategory(index)
+            layer.triggerRepaint()
+            _get_iface().layerTreeView().refreshLayerSymbology(layer.id())
+            layer.emitStyleChanged()  # Update symbology in layer styling panel
+
+    return res
 
 
 def create_layer(name, path="MultiPolygon"):

--- a/pzp/utils/utils.py
+++ b/pzp/utils/utils.py
@@ -17,7 +17,7 @@ from qgis.core import (
     QgsProject,
     QgsVectorLayer,
 )
-from qgis.PyQt.QtCore import Qt, QVariant
+from qgis.PyQt.QtCore import QMetaType, Qt, QVariant
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QPushButton
 from qgis.PyQt.uic import loadUiType
@@ -251,12 +251,31 @@ def get_ui_class(ui_file):
     return loadUiType(ui_file)[0]
 
 
-def add_field_to_layer(layer, name, alias="", variant=QVariant.Int):
+def add_field_to_layer(layer: QgsVectorLayer, name: str, alias: str = "", variant: QVariant = QVariant.Int) -> None:
     field = QgsField(name, variant)
     field.setAlias(alias)
     pr = layer.dataProvider()
     pr.addAttributes([field])
     layer.updateFields()
+
+
+def add_virtual_field_to_layer(
+    layer: QgsVectorLayer, name: str, alias: str = "", variant: QMetaType = QMetaType.Int, expression: str = ""
+) -> None:
+    field = QgsField(name, variant)
+    layer.addExpressionField(expression, field)
+    set_field_alias(layer, alias, field_name=name)
+
+
+def set_field_alias(layer: QgsVectorLayer, field_alias: str, field_index: int = -1, field_name: str = "") -> None:
+    if field_index == -1 and not field_name.strip():
+        return
+
+    if field_index == -1:
+        field_index = layer.fields().indexOf(field_name)
+
+    if field_index != -1:
+        layer.setFieldAlias(field_index, field_alias)
 
 
 def set_value_map_to_field(layer, field_name, domain_map):
@@ -314,10 +333,11 @@ def set_expression_constraint_to_field(layer, field_name, expression, descriptio
     layer.setConstraintExpression(index, expression, description)
 
 
-def set_qml_style(layer, qml_name):
+def set_qml_style(layer, qml_name, load_from_local_db=False):
+    # load_from_local_db=True forces to load from the given QML, regardless of the GPKG style
     current_dir = os.path.dirname(os.path.abspath(__file__))
     qml_file_path = os.path.join(current_dir, "../qml", f"{qml_name}.qml")
-    layer.loadNamedStyle(qml_file_path)
+    layer.loadNamedStyle(qml_file_path, load_from_local_db)
 
 
 def remove_renderer_category(layer: QgsVectorLayer, category_value: str) -> bool:
@@ -402,6 +422,12 @@ def set_value_relation_field(layer, field_name, other_layer, key_field, value_fi
         },
     )
 
+    index = layer.fields().indexOf(field_name)
+    layer.setEditorWidgetSetup(index, widget)
+
+
+def set_range_to_field(layer: QgsVectorLayer, field_name: str, config: dict) -> None:
+    widget = QgsEditorWidgetSetup("Range", config)
     index = layer.fields().indexOf(field_name)
     layer.setEditorWidgetSetup(index, widget)
 


### PR DESCRIPTION
 + [x] Add new layer "Zona sorgente (fonte processo)"
    + [x] Assign symbology
 + [x] Move fonte di processo Value Map to the new layer (all layers)

 + [x] Layer Probabilità di propagazione
     + [x] Layer structure
         + [x] Alias for fid (new method in utils)
         + [x] proc_parz (domain from QML) and default value
         + [x] Add virtual field (new method in utils)
     + [x] Attribute forms
         + [x] Set range widget for virtual field (new method in utils)*
         + [x] Add description to `fonte_proc` Value Map
        ![image](https://github.com/user-attachments/assets/77db9f27-0008-4ed9-ba5c-577ec6d000d3)
    + [x] Modify QML (store LayerConfiguration|Symbology|Labeling|Forms), i.e., no Fields to avoid transforming the virtual field into a provider field when saving to GPKG.
     + [x] Adjust filtered layers (set variables, virtual field and its widget, geometry options, alias for fid).
     + [x] Replace symbology Propagazione
        ![image](https://github.com/user-attachments/assets/4ce11770-8deb-469c-8cdf-454686d028b4)


 + [x] Layer Probabilità di rottura
     + [x] Layer structure
         + [x] Alias for fid (new method in utils)
         + [x] proc_parz (domain from QML) and default value
         + [x] Add virtual field (new method in utils)
     + [x] Attribute forms
         + [x] Set range widget for virtual field (new method in utils)*        
         + [x] Add description to `fonte_proc` Value Map
        ![image](https://github.com/user-attachments/assets/ff99e410-de0c-4a94-a760-5bf7b03a975a)
    + [x] Modify QML (store Symbology|Labeling|Forms), i.e., no Fields to avoid transforming the virtual field into a provider field when saving to GPKG.
     + [x] Adjust filtered layers (set variables, virtual field and its widget, geometry options, alias for fid).


 + [x] Others
    + [x] In calcola propagazione, remove category "impatto presente" from layer Intensità completa. Actually, only from all its  filtered layers but T>300.
        ![image](https://github.com/user-attachments/assets/019e2e3e-6f86-4c93-ae35-78e9ceff2384)
    + [x]  In Calcola propagazione, make sure we set proper value relations for Intensità layer (fonte_proc) and its filtered layers, as well as a proper @pzp_process variable for the filtered layers, so that the default expression in proc_parz field works as expected when adding new features


-----------

_* This widget definition couldn't be stored in the QML, because doing so would transform the Virtual Field into a provider field when saving the styles into GPKG._