### PR TITLE
[fix] Replace QMetaType (available since QGIS 3.38) by QVariant

### DIFF
--- a/pzp/add_process.py
+++ b/pzp/add_process.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 
 from qgis.core import QgsExpressionContextUtils, QgsProject
-from qgis.PyQt.QtCore import QMetaType, QVariant
+from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox
 
 from pzp.processing import domains
@@ -148,7 +148,7 @@ End
             # Virtual field should be set on the loaded layer from GPKG
             # (and the QML style should not contain the Fields category when exported,
             # otherwise the virtual field would be stored as a normal field in the GPKG)
-            utils.add_virtual_field_to_layer(_layer, "lunghezza", "Lunghezza in metri", QMetaType.Double, "$length")
+            utils.add_virtual_field_to_layer(_layer, "lunghezza", "Lunghezza in metri", QVariant.Double, "$length")
 
             # Configure widget for virtual field (not included in the QML)
             _config = {
@@ -242,7 +242,7 @@ End
             # Virtual field should be set on the loaded layer from GPKG
             # (and the QML style should not contain the Fields category when exported,
             # otherwise the virtual field would be stored as a normal field in the GPKG)
-            utils.add_virtual_field_to_layer(_layer, "area", "Area in m2", QMetaType.Double, "$area")
+            utils.add_virtual_field_to_layer(_layer, "area", "Area in m2", QVariant.Double, "$area")
 
             # Configure widget for virtual field (not included in the QML)
             _config = {

--- a/pzp/utils/utils.py
+++ b/pzp/utils/utils.py
@@ -17,7 +17,7 @@ from qgis.core import (
     QgsProject,
     QgsVectorLayer,
 )
-from qgis.PyQt.QtCore import QMetaType, Qt, QVariant
+from qgis.PyQt.QtCore import Qt, QVariant
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QPushButton
 from qgis.PyQt.uic import loadUiType
@@ -260,7 +260,7 @@ def add_field_to_layer(layer: QgsVectorLayer, name: str, alias: str = "", varian
 
 
 def add_virtual_field_to_layer(
-    layer: QgsVectorLayer, name: str, alias: str = "", variant: QMetaType = QMetaType.Int, expression: str = ""
+    layer: QgsVectorLayer, name: str, alias: str = "", variant: QVariant = QVariant.Int, expression: str = ""
 ) -> None:
     field = QgsField(name, variant)
     layer.addExpressionField(expression, field)


### PR DESCRIPTION
So that the plugin can still work on older QGIS versions.