### PR TITLE
In Calcola propagazione, avoid overriding previous intensity layers

### DIFF
--- a/pzp/calculation.py
+++ b/pzp/calculation.py
@@ -196,8 +196,6 @@ class PropagationTool:
             _idx = _layer.fields().indexOf("fonte_proc")
             _layer.setEditorWidgetSetup(_idx, _widget)
 
-            # pzp_layer variable could come from QML, it should be reset (removed), but no current API to do so
-            QgsExpressionContextUtils.setLayerVariable(_layer, "pzp_layer", None)
             QgsExpressionContextUtils.setLayerVariable(_layer, "pzp_process", process_type)
 
         _set_common_post_configurations(new_layer, base_layer)

--- a/pzp/calculation.py
+++ b/pzp/calculation.py
@@ -4,6 +4,7 @@ import traceback
 from qgis import processing
 from qgis.core import (
     QgsExpressionContextUtils,
+    QgsLayerTreeLayer,
     QgsProcessingException,
     QgsProject,
     QgsVectorLayer,
@@ -19,11 +20,34 @@ class PropagationTool:
         self._tool_name = "Calcolo propagazione"
 
     def _guess_params(self):
+        def _archive_previous_intensity_layers(intensity_group):
+            # Create or get Archivio group
+            archive_group_name = "Intensità completa - Archivio"
+            archive_group = intensity_group.findGroup(archive_group_name)
+            if not archive_group:
+                archive_group = intensity_group.addGroup(archive_group_name)
+
+            # Get all intensity group (layer) children, actually their clones, to be moved
+            children_layers = [
+                child.clone() for child in intensity_group.children() if isinstance(child, QgsLayerTreeLayer)
+            ]
+
+            # Move them to the top of the group (so we always end up with the newest first)
+            archive_group.insertChildNodes(0, children_layers)
+            for child in [child for child in intensity_group.children() if isinstance(child, QgsLayerTreeLayer)]:
+                intensity_group.removeChildNode(child)
+
+            # Collapse and turn off the group
+            archive_group.setExpanded(False)
+            archive_group.setItemVisibilityChecked(False)
+
         # process and layers
         layer_nodes = self._group.findLayers()
         process_type = None
         layer_propagation = None
         layer_breaking = None
+        previous_intensity_layer_found = False
+        previous_intensity_group = None
 
         for layer_node in layer_nodes:
             pzp_layer = QgsExpressionContextUtils.layerScope(layer_node.layer()).variable("pzp_layer")
@@ -33,6 +57,15 @@ class PropagationTool:
             elif pzp_layer == "breaking":
                 layer_breaking = layer_node.layer()
                 process_type = int(QgsExpressionContextUtils.layerScope(layer_breaking).variable("pzp_process"))
+            elif pzp_layer == "intensity":
+                # Intensity layer was found from previous executions: Update its pzp_variable
+                # and move it (and its filtered layers) to a group 'Archivio'
+                QgsExpressionContextUtils.setLayerVariable(layer_node.layer(), "pzp_layer", "intensity_old")
+                previous_intensity_group = layer_node.parent()
+                previous_intensity_layer_found = True
+
+        if previous_intensity_layer_found:
+            _archive_previous_intensity_layers(previous_intensity_group)
 
         if not layer_propagation:
             utils.push_error("Layer con le probabilità di propagazione non trovato", 3)
@@ -73,7 +106,7 @@ class PropagationTool:
             return None
 
         gpkg_path = layer_breaking.dataProvider().dataSourceUri().split("|")[0]
-        layer_name = "Intensità completa"
+        layer_name = f"Intensità completa {process_type} {datetime.datetime.now().strftime('%Y%m%d%H%M%S')}"
         self._save_layer(layer_intensity, layer_name, gpkg_path)
 
         new_layer = self._load_layer_to_project(process_type, gpkg_path, layer_name, layer_propagation)
@@ -163,14 +196,22 @@ class PropagationTool:
             _idx = _layer.fields().indexOf("fonte_proc")
             _layer.setEditorWidgetSetup(_idx, _widget)
 
+            # pzp_layer variable could come from QML, it should be reset (removed), but no current API to do so
+            QgsExpressionContextUtils.setLayerVariable(_layer, "pzp_layer", None)
             QgsExpressionContextUtils.setLayerVariable(_layer, "pzp_process", process_type)
 
         _set_common_post_configurations(new_layer, base_layer)
 
-        group_intensity_filtered = utils.create_group("Intensità (con filtri x visualizzazione scenari)", self._group)
+        intensity_group_name = "Intensità (con filtri x visualizzazione scenari)"
+        group_intensity_filtered = self._group.findGroup(intensity_group_name)
+        if not group_intensity_filtered:
+            group_intensity_filtered = utils.create_group(intensity_group_name, self._group)
+
         group_intensity_filtered.setExpanded(True)
 
-        group_intensity_filtered.addLayer(new_layer)
+        intensity_children_count = len(group_intensity_filtered.children())
+        position = 0 if intensity_children_count == 0 else intensity_children_count - 1
+        group_intensity_filtered.insertLayer(position, new_layer)  # Just before an eventual archive group
 
         filter_params = [
             ("\"periodo_ritorno\"='30'", "T 30", True),
@@ -192,7 +233,8 @@ class PropagationTool:
                 utils.remove_renderer_category(gpkg_layer, "1001")
 
             project.addMapLayer(gpkg_layer, False)
-            group_intensity_filtered.addLayer(gpkg_layer)
+            position += 1
+            group_intensity_filtered.insertLayer(position, gpkg_layer)
             _set_common_post_configurations(gpkg_layer, base_layer)
             layer_node = self._group.findLayer(gpkg_layer.id())
             layer_node.setExpanded(False)

--- a/pzp/qml/danger_level.qml
+++ b/pzp/qml/danger_level.qml
@@ -1,510 +1,510 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" version="3.34.9-Prizren" labelsEnabled="1" minScale="0" readOnly="0" styleCategories="AllStyleCategories" maxScale="0" simplifyLocal="1" symbologyReferenceScale="-1">
+<qgis version="3.43.0-Master" simplifyAlgorithm="0" autoRefreshMode="Disabled" autoRefreshTime="0" simplifyDrawingTol="1" maxScale="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" simplifyDrawingHints="1" labelsEnabled="1" readOnly="0" minScale="0" symbologyReferenceScale="-1" styleCategories="LayerConfiguration|Symbology|Symbology3D|Labeling|Fields|Forms|Actions|MapTips|Diagrams|AttributeTable|Rendering|GeometryOptions|Relations|Temporal|Legend|Elevation|Notes">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <temporal limitMode="0" endField="" accumulate="0" startField="" startExpression="" endExpression="" enabled="0" fixedDuration="0" mode="0" durationUnit="min" durationField="fid">
+  <temporal durationField="fid" startExpression="" durationUnit="min" startField="" accumulate="0" limitMode="0" endExpression="" mode="0" endField="" fixedDuration="0" enabled="0">
     <fixedRange>
       <start></start>
       <end></end>
     </fixedRange>
   </temporal>
-  <elevation binding="Centroid" type="IndividualFeatures" zoffset="0" extrusionEnabled="0" zscale="1" symbology="Line" showMarkerSymbolInSurfacePlots="0" respectLayerSymbol="1" extrusion="0" clamping="Terrain">
+  <elevation extrusion="0" symbology="Line" zoffset="0" clamping="Terrain" type="IndividualFeatures" zscale="1" extrusionEnabled="0" customToleranceEnabled="0" respectLayerSymbol="1" binding="Centroid" showMarkerSymbolInSurfacePlots="0">
     <data-defined-properties>
       <Option type="Map">
-        <Option type="QString" value="" name="name"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </data-defined-properties>
     <profileLineSymbol>
-      <symbol alpha="1" clip_to_extent="1" type="line" is_animated="0" force_rhr="0" name="" frame_rate="10">
+      <symbol alpha="1" frame_rate="10" force_rhr="0" type="line" is_animated="0" name="" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleLine" locked="0" id="{ea5ec76b-5787-4781-adb6-360295f2e398}" enabled="1" pass="0">
+        <layer class="SimpleLine" locked="0" pass="0" enabled="1" id="{ea5ec76b-5787-4781-adb6-360295f2e398}">
           <Option type="Map">
-            <Option type="QString" value="0" name="align_dash_pattern"/>
-            <Option type="QString" value="square" name="capstyle"/>
-            <Option type="QString" value="5;2" name="customdash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-            <Option type="QString" value="MM" name="customdash_unit"/>
-            <Option type="QString" value="0" name="dash_pattern_offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-            <Option type="QString" value="0" name="draw_inside_polygon"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="125,139,143,255" name="line_color"/>
-            <Option type="QString" value="solid" name="line_style"/>
-            <Option type="QString" value="0.6" name="line_width"/>
-            <Option type="QString" value="MM" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="0" name="trim_distance_end"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-            <Option type="QString" value="0" name="trim_distance_start"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-            <Option type="QString" value="0" name="use_custom_dash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="square" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="0.6" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </profileLineSymbol>
     <profileFillSymbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="" frame_rate="10">
+      <symbol alpha="1" frame_rate="10" force_rhr="0" type="fill" is_animated="0" name="" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{b824cc6f-73ea-4a82-94f1-87b6a9e039c2}" enabled="1" pass="0">
+        <layer class="SimpleFill" locked="0" pass="0" enabled="1" id="{b824cc6f-73ea-4a82-94f1-87b6a9e039c2}">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="125,139,143,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="89,99,102,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.2" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="89,99,102,255,rgb:0.34901960784313724,0.38823529411764707,0.40000000000000002,1" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.2" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </profileFillSymbol>
     <profileMarkerSymbol>
-      <symbol alpha="1" clip_to_extent="1" type="marker" is_animated="0" force_rhr="0" name="" frame_rate="10">
+      <symbol alpha="1" frame_rate="10" force_rhr="0" type="marker" is_animated="0" name="" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleMarker" locked="0" id="{523535d0-1386-420f-bff4-0512067f5982}" enabled="1" pass="0">
+        <layer class="SimpleMarker" locked="0" pass="0" enabled="1" id="{523535d0-1386-420f-bff4-0512067f5982}">
           <Option type="Map">
-            <Option type="QString" value="0" name="angle"/>
-            <Option type="QString" value="square" name="cap_style"/>
-            <Option type="QString" value="125,139,143,255" name="color"/>
-            <Option type="QString" value="1" name="horizontal_anchor_point"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="diamond" name="name"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="89,99,102,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.2" name="outline_width"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="diameter" name="scale_method"/>
-            <Option type="QString" value="3" name="size"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
-            <Option type="QString" value="MM" name="size_unit"/>
-            <Option type="QString" value="1" name="vertical_anchor_point"/>
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="125,139,143,255,rgb:0.49019607843137253,0.54509803921568623,0.5607843137254902,1" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="diamond" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="89,99,102,255,rgb:0.34901960784313724,0.38823529411764707,0.40000000000000002,1" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.2" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="3" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </profileMarkerSymbol>
   </elevation>
-  <renderer-v2 type="categorizedSymbol" attr="grado_pericolo" symbollevels="1" enableorderby="0" forceraster="0" referencescale="-1">
+  <renderer-v2 enableorderby="0" referencescale="-1" type="categorizedSymbol" symbollevels="1" forceraster="0" attr="grado_pericolo">
     <categories>
-      <category label="elevato" type="string" uuid="0" render="true" symbol="0" value="1004"/>
-      <category label="medio" type="string" uuid="1" render="true" symbol="1" value="1003"/>
-      <category label="basso" type="string" uuid="2" render="true" symbol="2" value="1002"/>
-      <category label="residuo" type="string" uuid="3" render="true" symbol="3" value="1001"/>
-      <category label="non in pericolo" type="string" uuid="4" render="true" symbol="4" value="1000"/>
+      <category render="true" value="1004" type="string" symbol="0" uuid="0" label="elevato"/>
+      <category render="true" value="1003" type="string" symbol="1" uuid="1" label="medio"/>
+      <category render="true" value="1002" type="string" symbol="2" uuid="2" label="basso"/>
+      <category render="true" value="1001" type="string" symbol="3" uuid="3" label="residuo"/>
+      <category render="true" value="1000" type="string" symbol="4" uuid="4" label="non in pericolo"/>
     </categories>
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="0" frame_rate="10">
+      <symbol alpha="1" frame_rate="10" force_rhr="0" type="fill" is_animated="0" name="0" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{73ebecc3-bebd-4d20-8f7a-8afd13cf3397}" enabled="1" pass="5">
+        <layer class="SimpleFill" locked="0" pass="5" enabled="1" id="{73ebecc3-bebd-4d20-8f7a-8afd13cf3397}">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="255,93,81,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="35,35,35,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.26" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="255,93,81,255,rgb:1,0.36470588235294116,0.31764705882352939,1" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="1" frame_rate="10">
+      <symbol alpha="1" frame_rate="10" force_rhr="0" type="fill" is_animated="0" name="1" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{93637e6d-2334-4594-aecd-d9c209560b64}" enabled="1" pass="4">
+        <layer class="SimpleFill" locked="0" pass="4" enabled="1" id="{93637e6d-2334-4594-aecd-d9c209560b64}">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="85,142,213,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="35,35,35,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.26" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="85,142,213,255,rgb:0.33333333333333331,0.55686274509803924,0.83529411764705885,1" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="2" frame_rate="10">
+      <symbol alpha="1" frame_rate="10" force_rhr="0" type="fill" is_animated="0" name="2" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{89d20c7a-44ba-470b-ae41-78c3d557d493}" enabled="1" pass="3">
+        <layer class="SimpleFill" locked="0" pass="3" enabled="1" id="{89d20c7a-44ba-470b-ae41-78c3d557d493}">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="255,248,103,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="35,35,35,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.26" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="255,248,103,255,rgb:1,0.97254901960784312,0.40392156862745099,1" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="3" frame_rate="10">
+      <symbol alpha="1" frame_rate="10" force_rhr="0" type="fill" is_animated="0" name="3" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{89e5dda7-ed3e-4e7d-9509-90bfc909e0de}" enabled="1" pass="1">
+        <layer class="SimpleFill" locked="0" pass="1" enabled="1" id="{89e5dda7-ed3e-4e7d-9509-90bfc909e0de}">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="255,255,255,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="35,35,35,0" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.26" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="255,255,255,255,rgb:1,1,1,1" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,0,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,0" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="LinePatternFill" locked="0" id="{44c34ce4-6d74-4238-90ec-18c36f08dca2}" enabled="1" pass="2">
+        <layer class="LinePatternFill" locked="0" pass="2" enabled="1" id="{44c34ce4-6d74-4238-90ec-18c36f08dca2}">
           <Option type="Map">
-            <Option type="QString" value="45" name="angle"/>
-            <Option type="QString" value="during_render" name="clip_mode"/>
-            <Option type="QString" value="0,0,0,255" name="color"/>
-            <Option type="QString" value="feature" name="coordinate_reference"/>
-            <Option type="QString" value="1.5" name="distance"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="distance_map_unit_scale"/>
-            <Option type="QString" value="MM" name="distance_unit"/>
-            <Option type="QString" value="0.5" name="line_width"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="line_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option value="45" type="QString" name="angle"/>
+            <Option value="during_render" type="QString" name="clip_mode"/>
+            <Option value="0,0,0,255,rgb:0,0,0,1" type="QString" name="color"/>
+            <Option value="feature" type="QString" name="coordinate_reference"/>
+            <Option value="1.5" type="QString" name="distance"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="distance_map_unit_scale"/>
+            <Option value="MM" type="QString" name="distance_unit"/>
+            <Option value="0.5" type="QString" name="line_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="line_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol alpha="1" clip_to_extent="1" type="line" is_animated="0" force_rhr="0" name="@3@1" frame_rate="10">
+          <symbol alpha="1" frame_rate="10" force_rhr="0" type="line" is_animated="0" name="@3@1" clip_to_extent="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleLine" locked="0" id="{5030b0d0-795c-4f75-b693-78852bf6ae04}" enabled="1" pass="0">
+            <layer class="SimpleLine" locked="0" pass="0" enabled="1" id="{5030b0d0-795c-4f75-b693-78852bf6ae04}">
               <Option type="Map">
-                <Option type="QString" value="0" name="align_dash_pattern"/>
-                <Option type="QString" value="square" name="capstyle"/>
-                <Option type="QString" value="5;2" name="customdash"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-                <Option type="QString" value="MM" name="customdash_unit"/>
-                <Option type="QString" value="0" name="dash_pattern_offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-                <Option type="QString" value="0" name="draw_inside_polygon"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="255,248,103,255" name="line_color"/>
-                <Option type="QString" value="solid" name="line_style"/>
-                <Option type="QString" value="0.4" name="line_width"/>
-                <Option type="QString" value="MM" name="line_width_unit"/>
-                <Option type="QString" value="0" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="offset_unit"/>
-                <Option type="QString" value="0" name="ring_filter"/>
-                <Option type="QString" value="0" name="trim_distance_end"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-                <Option type="QString" value="0" name="trim_distance_start"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-                <Option type="QString" value="0" name="use_custom_dash"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+                <Option value="0" type="QString" name="align_dash_pattern"/>
+                <Option value="square" type="QString" name="capstyle"/>
+                <Option value="5;2" type="QString" name="customdash"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+                <Option value="MM" type="QString" name="customdash_unit"/>
+                <Option value="0" type="QString" name="dash_pattern_offset"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+                <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+                <Option value="0" type="QString" name="draw_inside_polygon"/>
+                <Option value="bevel" type="QString" name="joinstyle"/>
+                <Option value="255,248,103,255,rgb:1,0.97254901960784312,0.40392156862745099,1" type="QString" name="line_color"/>
+                <Option value="solid" type="QString" name="line_style"/>
+                <Option value="0.4" type="QString" name="line_width"/>
+                <Option value="MM" type="QString" name="line_width_unit"/>
+                <Option value="0" type="QString" name="offset"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                <Option value="MM" type="QString" name="offset_unit"/>
+                <Option value="0" type="QString" name="ring_filter"/>
+                <Option value="0" type="QString" name="trim_distance_end"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+                <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+                <Option value="0" type="QString" name="trim_distance_start"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+                <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+                <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+                <Option value="0" type="QString" name="use_custom_dash"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer class="SimpleFill" locked="0" id="{8091ea76-de0f-437f-9e7e-b8c0cdc720b4}" enabled="1" pass="2">
+        <layer class="SimpleFill" locked="0" pass="2" enabled="1" id="{8091ea76-de0f-437f-9e7e-b8c0cdc720b4}">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="0,0,255,0" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="35,35,35,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.16" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="0,0,255,0,rgb:0,0,1,0" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.16" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="4" frame_rate="10">
+      <symbol alpha="1" frame_rate="10" force_rhr="0" type="fill" is_animated="0" name="4" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="LinePatternFill" locked="0" id="{314b3ee4-d9fd-422e-91d0-3036040057ed}" enabled="1" pass="0">
+        <layer class="LinePatternFill" locked="0" pass="0" enabled="1" id="{314b3ee4-d9fd-422e-91d0-3036040057ed}">
           <Option type="Map">
-            <Option type="QString" value="45" name="angle"/>
-            <Option type="QString" value="during_render" name="clip_mode"/>
-            <Option type="QString" value="0,0,0,255" name="color"/>
-            <Option type="QString" value="feature" name="coordinate_reference"/>
-            <Option type="QString" value="2.2" name="distance"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="distance_map_unit_scale"/>
-            <Option type="QString" value="MM" name="distance_unit"/>
-            <Option type="QString" value="0.5" name="line_width"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="line_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option value="45" type="QString" name="angle"/>
+            <Option value="during_render" type="QString" name="clip_mode"/>
+            <Option value="0,0,0,255,rgb:0,0,0,1" type="QString" name="color"/>
+            <Option value="feature" type="QString" name="coordinate_reference"/>
+            <Option value="2.2" type="QString" name="distance"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="distance_map_unit_scale"/>
+            <Option value="MM" type="QString" name="distance_unit"/>
+            <Option value="0.5" type="QString" name="line_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="line_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
-          <symbol alpha="1" clip_to_extent="1" type="line" is_animated="0" force_rhr="0" name="@4@0" frame_rate="10">
+          <symbol alpha="1" frame_rate="10" force_rhr="0" type="line" is_animated="0" name="@4@0" clip_to_extent="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleLine" locked="0" id="{841c1af7-5773-479d-b380-6b09ffa2f650}" enabled="1" pass="0">
+            <layer class="SimpleLine" locked="0" pass="0" enabled="1" id="{841c1af7-5773-479d-b380-6b09ffa2f650}">
               <Option type="Map">
-                <Option type="QString" value="0" name="align_dash_pattern"/>
-                <Option type="QString" value="square" name="capstyle"/>
-                <Option type="QString" value="5;2" name="customdash"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-                <Option type="QString" value="MM" name="customdash_unit"/>
-                <Option type="QString" value="0" name="dash_pattern_offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-                <Option type="QString" value="0" name="draw_inside_polygon"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="130,130,130,255" name="line_color"/>
-                <Option type="QString" value="solid" name="line_style"/>
-                <Option type="QString" value="0.2" name="line_width"/>
-                <Option type="QString" value="MM" name="line_width_unit"/>
-                <Option type="QString" value="0" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="offset_unit"/>
-                <Option type="QString" value="0" name="ring_filter"/>
-                <Option type="QString" value="0" name="trim_distance_end"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-                <Option type="QString" value="0" name="trim_distance_start"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-                <Option type="QString" value="0" name="use_custom_dash"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+                <Option value="0" type="QString" name="align_dash_pattern"/>
+                <Option value="square" type="QString" name="capstyle"/>
+                <Option value="5;2" type="QString" name="customdash"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+                <Option value="MM" type="QString" name="customdash_unit"/>
+                <Option value="0" type="QString" name="dash_pattern_offset"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+                <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+                <Option value="0" type="QString" name="draw_inside_polygon"/>
+                <Option value="bevel" type="QString" name="joinstyle"/>
+                <Option value="130,130,130,255,rgb:0.50980392156862742,0.50980392156862742,0.50980392156862742,1" type="QString" name="line_color"/>
+                <Option value="solid" type="QString" name="line_style"/>
+                <Option value="0.2" type="QString" name="line_width"/>
+                <Option value="MM" type="QString" name="line_width_unit"/>
+                <Option value="0" type="QString" name="offset"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                <Option value="MM" type="QString" name="offset_unit"/>
+                <Option value="0" type="QString" name="ring_filter"/>
+                <Option value="0" type="QString" name="trim_distance_end"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+                <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+                <Option value="0" type="QString" name="trim_distance_start"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+                <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+                <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+                <Option value="0" type="QString" name="use_custom_dash"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer class="SimpleFill" locked="0" id="{2c7c3106-7b1a-46cd-80ae-93ca50b85196}" enabled="1" pass="0">
+        <layer class="SimpleFill" locked="0" pass="0" enabled="1" id="{2c7c3106-7b1a-46cd-80ae-93ca50b85196}">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="0,0,255,0" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="35,35,35,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.2" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="0,0,255,0,rgb:0,0,1,0" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.2" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <source-symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="0" frame_rate="10">
+      <symbol alpha="1" frame_rate="10" force_rhr="0" type="fill" is_animated="0" name="0" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{71ecc105-eb09-494e-aa56-7d6773349585}" enabled="1" pass="0">
+        <layer class="SimpleFill" locked="0" pass="0" enabled="1" id="{71ecc105-eb09-494e-aa56-7d6773349585}">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="0,0,255,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="35,35,35,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.26" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="0,0,255,255,rgb:0,0,1,1" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -512,37 +512,44 @@
     </source-symbol>
     <rotation/>
     <sizescale/>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option value="" type="QString" name="name"/>
+        <Option name="properties"/>
+        <Option value="collection" type="QString" name="type"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
   <selection mode="Default">
     <selectionColor invalid="1"/>
     <selectionSymbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="" frame_rate="10">
+      <symbol alpha="1" frame_rate="10" force_rhr="0" type="fill" is_animated="0" name="" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{e989ef3d-2fea-4a27-bce0-40c26fc6488f}" enabled="1" pass="0">
+        <layer class="SimpleFill" locked="0" pass="0" enabled="1" id="{e989ef3d-2fea-4a27-bce0-40c26fc6488f}">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="0,0,255,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="35,35,35,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.26" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="0,0,255,255,rgb:0,0,1,1" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.26" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -551,255 +558,228 @@
   </selection>
   <labeling type="simple">
     <settings calloutType="simple">
-      <text-style fontWordSpacing="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" allowHtml="0" previewBkgrdColor="255,255,255,255" capitalization="0" fieldName="matrice" forcedItalic="0" fontFamily="MS Shell Dlg 2" fontWeight="50" namedStyle="Normale" fontSize="10" fontSizeUnit="Point" isExpression="0" multilineHeightUnit="Percentage" textColor="0,0,0,255" textOrientation="horizontal" fontStrikeout="0" forcedBold="0" textOpacity="1" legendString="Aa" fontUnderline="0" blendMode="0" fontItalic="0" fontKerning="1" multilineHeight="1" fontLetterSpacing="0" useSubstitutions="1">
+      <text-style allowHtml="0" useSubstitutions="1" fontStrikeout="0" fontKerning="1" fontWordSpacing="0" fontWeight="50" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontFamily="Ubuntu Sans" forcedItalic="0" multilineHeight="1" textOpacity="1" blendMode="0" isExpression="0" tabStopDistance="80" fontItalic="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" multilineHeightUnit="Percentage" textColor="0,0,0,255,rgb:0,0,0,1" capitalization="0" fontSizeUnit="Point" fontLetterSpacing="0" legendString="Aa" fontSize="10" fieldName="matrice" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" forcedBold="0" fontUnderline="0" textOrientation="horizontal" namedStyle="Regular" tabStopDistanceUnit="Point">
         <families/>
-        <text-buffer bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferSize="1" bufferOpacity="1" bufferNoFill="1" bufferJoinStyle="128" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferDraw="0"/>
-        <text-mask maskSizeUnits="MM" maskOpacity="1" maskedSymbolLayers="" maskEnabled="0" maskType="0" maskJoinStyle="128" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-        <background shapeSVGFile="" shapeBorderWidthUnit="MM" shapeOffsetX="0" shapeOffsetUnit="MM" shapeSizeX="0" shapeOpacity="1" shapeBlendMode="0" shapeRotationType="0" shapeDraw="0" shapeOffsetY="0" shapeRadiiUnit="MM" shapeType="0" shapeFillColor="255,255,255,255" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidth="0" shapeSizeUnit="MM" shapeRadiiY="0" shapeSizeType="0" shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderColor="128,128,128,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeJoinStyle="64" shapeSizeY="0">
-          <symbol alpha="1" clip_to_extent="1" type="marker" is_animated="0" force_rhr="0" name="markerSymbol" frame_rate="10">
+        <text-buffer bufferSizeUnits="MM" bufferDraw="0" bufferOpacity="1" bufferBlendMode="0" bufferNoFill="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="255,255,255,255,rgb:1,1,1,1" bufferJoinStyle="128"/>
+        <text-mask maskSize="1.5" maskedSymbolLayers="" maskJoinStyle="128" maskOpacity="1" maskSize2="1.5" maskSizeUnits="MM" maskType="0" maskEnabled="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+        <background shapeBorderWidthUnit="MM" shapeBorderWidth="0" shapeSizeY="0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeJoinStyle="64" shapeDraw="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeRotation="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeOffsetX="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetY="0" shapeSizeType="0" shapeBlendMode="0" shapeRotationType="0" shapeSizeUnit="MM" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiY="0" shapeType="0" shapeSVGFile="" shapeSizeX="0" shapeRadiiUnit="MM" shapeRadiiX="0">
+          <symbol alpha="1" frame_rate="10" force_rhr="0" type="marker" is_animated="0" name="markerSymbol" clip_to_extent="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleMarker" locked="0" id="" enabled="1" pass="0">
+            <layer class="SimpleMarker" locked="0" pass="0" enabled="1" id="">
               <Option type="Map">
-                <Option type="QString" value="0" name="angle"/>
-                <Option type="QString" value="square" name="cap_style"/>
-                <Option type="QString" value="141,90,153,255" name="color"/>
-                <Option type="QString" value="1" name="horizontal_anchor_point"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="circle" name="name"/>
-                <Option type="QString" value="0,0" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="offset_unit"/>
-                <Option type="QString" value="35,35,35,255" name="outline_color"/>
-                <Option type="QString" value="solid" name="outline_style"/>
-                <Option type="QString" value="0" name="outline_width"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-                <Option type="QString" value="MM" name="outline_width_unit"/>
-                <Option type="QString" value="diameter" name="scale_method"/>
-                <Option type="QString" value="2" name="size"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
-                <Option type="QString" value="MM" name="size_unit"/>
-                <Option type="QString" value="1" name="vertical_anchor_point"/>
+                <Option value="0" type="QString" name="angle"/>
+                <Option value="square" type="QString" name="cap_style"/>
+                <Option value="141,90,153,255,rgb:0.55294117647058827,0.35294117647058826,0.59999999999999998,1" type="QString" name="color"/>
+                <Option value="1" type="QString" name="horizontal_anchor_point"/>
+                <Option value="bevel" type="QString" name="joinstyle"/>
+                <Option value="circle" type="QString" name="name"/>
+                <Option value="0,0" type="QString" name="offset"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                <Option value="MM" type="QString" name="offset_unit"/>
+                <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="outline_color"/>
+                <Option value="solid" type="QString" name="outline_style"/>
+                <Option value="0" type="QString" name="outline_width"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+                <Option value="MM" type="QString" name="outline_width_unit"/>
+                <Option value="diameter" type="QString" name="scale_method"/>
+                <Option value="2" type="QString" name="size"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+                <Option value="MM" type="QString" name="size_unit"/>
+                <Option value="1" type="QString" name="vertical_anchor_point"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="fillSymbol" frame_rate="10">
+          <symbol alpha="1" frame_rate="10" force_rhr="0" type="fill" is_animated="0" name="fillSymbol" clip_to_extent="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleFill" locked="0" id="" enabled="1" pass="0">
+            <layer class="SimpleFill" locked="0" pass="0" enabled="1" id="">
               <Option type="Map">
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-                <Option type="QString" value="255,255,255,255" name="color"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="0,0" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="offset_unit"/>
-                <Option type="QString" value="128,128,128,255" name="outline_color"/>
-                <Option type="QString" value="no" name="outline_style"/>
-                <Option type="QString" value="0" name="outline_width"/>
-                <Option type="QString" value="MM" name="outline_width_unit"/>
-                <Option type="QString" value="solid" name="style"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+                <Option value="255,255,255,255,rgb:1,1,1,1" type="QString" name="color"/>
+                <Option value="bevel" type="QString" name="joinstyle"/>
+                <Option value="0,0" type="QString" name="offset"/>
+                <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+                <Option value="MM" type="QString" name="offset_unit"/>
+                <Option value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" type="QString" name="outline_color"/>
+                <Option value="no" type="QString" name="outline_style"/>
+                <Option value="0" type="QString" name="outline_width"/>
+                <Option value="MM" type="QString" name="outline_width_unit"/>
+                <Option value="solid" type="QString" name="style"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option value="" type="QString" name="name"/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option value="collection" type="QString" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </background>
-        <shadow shadowUnder="0" shadowRadiusAlphaOnly="0" shadowOffsetUnit="MM" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowColor="0,0,0,255" shadowOffsetDist="1" shadowOffsetAngle="135" shadowScale="100" shadowRadius="1.5" shadowBlendMode="6" shadowRadiusUnit="MM" shadowDraw="0" shadowOpacity="0.69999999999999996"/>
+        <shadow shadowDraw="0" shadowRadius="1.5" shadowOffsetGlobal="1" shadowRadiusUnit="MM" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowUnder="0" shadowRadiusAlphaOnly="0" shadowScale="100" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOpacity="0.69999999999999996" shadowOffsetUnit="MM" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowBlendMode="6" shadowOffsetDist="1"/>
         <dd_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </dd_properties>
         <substitutions>
-          <replacement wholeWord="1" replace="0" match="1000" caseSensitive="0"/>
-          <replacement wholeWord="1" replace="9" match="1001" caseSensitive="0"/>
-          <replacement wholeWord="1" replace="8" match="1002" caseSensitive="0"/>
-          <replacement wholeWord="1" replace="7" match="1003" caseSensitive="0"/>
-          <replacement wholeWord="1" replace="6" match="1004" caseSensitive="0"/>
-          <replacement wholeWord="1" replace="5" match="1005" caseSensitive="0"/>
-          <replacement wholeWord="1" replace="4" match="1006" caseSensitive="0"/>
-          <replacement wholeWord="1" replace="3" match="1007" caseSensitive="0"/>
-          <replacement wholeWord="1" replace="2" match="1008" caseSensitive="0"/>
-          <replacement wholeWord="1" replace="1" match="1009" caseSensitive="0"/>
-          <replacement wholeWord="1" replace="-10" match="1010" caseSensitive="0"/>
+          <replacement caseSensitive="0" replace="0" wholeWord="1" match="1000"/>
+          <replacement caseSensitive="0" replace="9" wholeWord="1" match="1001"/>
+          <replacement caseSensitive="0" replace="8" wholeWord="1" match="1002"/>
+          <replacement caseSensitive="0" replace="7" wholeWord="1" match="1003"/>
+          <replacement caseSensitive="0" replace="6" wholeWord="1" match="1004"/>
+          <replacement caseSensitive="0" replace="5" wholeWord="1" match="1005"/>
+          <replacement caseSensitive="0" replace="4" wholeWord="1" match="1006"/>
+          <replacement caseSensitive="0" replace="3" wholeWord="1" match="1007"/>
+          <replacement caseSensitive="0" replace="2" wholeWord="1" match="1008"/>
+          <replacement caseSensitive="0" replace="1" wholeWord="1" match="1009"/>
+          <replacement caseSensitive="0" replace="-10" wholeWord="1" match="1010"/>
         </substitutions>
       </text-style>
-      <text-format rightDirectionSymbol=">" plussign="0" decimals="3" wrapChar="" placeDirectionSymbol="0" leftDirectionSymbol="&lt;" autoWrapLength="0" reverseDirectionSymbol="0" formatNumbers="0" addDirectionSymbol="0" multilineAlign="3" useMaxLineLengthForAutoWrap="1"/>
-      <placement geometryGenerator="" rotationAngle="0" dist="0" lineAnchorType="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" offsetType="0" quadOffset="4" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="0" rotationUnit="AngleDegrees" lineAnchorTextPoint="CenterOfText" fitInPolygonOnly="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" centroidWhole="0" geometryGeneratorEnabled="0" overrunDistanceUnit="MM" lineAnchorClipping="0" geometryGeneratorType="PointGeometry" maxCurvedCharAngleOut="-25" lineAnchorPercent="0.5" preserveRotation="1" priority="5" xOffset="0" distUnits="MM" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" overrunDistance="0" centroidInside="1" polygonPlacementFlags="2" repeatDistanceUnits="MM" layerType="PolygonGeometry" placementFlags="10" offsetUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" yOffset="0" overlapHandling="PreventOverlap" placement="0" repeatDistance="0" maxCurvedCharAngleIn="25"/>
-      <rendering maxNumLabels="2000" fontMinPixelSize="3" limitNumLabels="0" obstacleType="1" scaleMax="0" unplacedVisibility="0" minFeatureSize="0" scaleVisibility="0" fontLimitPixelSize="0" mergeLines="0" fontMaxPixelSize="10000" scaleMin="0" upsidedownLabels="0" labelPerPart="0" obstacle="1" obstacleFactor="1" zIndex="0" drawLabels="1"/>
+      <text-format formatNumbers="0" rightDirectionSymbol=">" plussign="0" useMaxLineLengthForAutoWrap="1" decimals="3" autoWrapLength="0" multilineAlign="3" addDirectionSymbol="0" wrapChar="" leftDirectionSymbol="&lt;" placeDirectionSymbol="0" reverseDirectionSymbol="0"/>
+      <placement maxCurvedCharAngleOut="-25" overrunDistanceUnit="MM" lineAnchorType="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" lineAnchorTextPoint="CenterOfText" fitInPolygonOnly="0" distMapUnitScale="3x:0,0,0,0,0,0" offsetUnits="MM" lineAnchorPercent="0.5" maximumDistanceUnit="MM" offsetType="0" distUnits="MM" xOffset="0" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" priority="5" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" rotationUnit="AngleDegrees" overrunDistance="0" yOffset="0" geometryGeneratorType="PointGeometry" prioritization="PreferCloser" preserveRotation="1" placementFlags="10" quadOffset="4" maxCurvedCharAngleIn="25" centroidInside="1" repeatDistanceUnits="MM" placement="0" polygonPlacementFlags="2" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" maximumDistance="0" geometryGenerator="" repeatDistance="0" centroidWhole="0" allowDegraded="0" dist="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" layerType="PolygonGeometry" overlapHandling="PreventOverlap" geometryGeneratorEnabled="0" rotationAngle="0" lineAnchorClipping="0"/>
+      <rendering obstacle="1" scaleMax="0" fontMaxPixelSize="10000" unplacedVisibility="0" labelPerPart="0" scaleVisibility="0" limitNumLabels="0" upsidedownLabels="0" drawLabels="1" scaleMin="0" obstacleFactor="1" mergeLines="0" zIndex="0" minFeatureSize="0" obstacleType="1" fontLimitPixelSize="0" maxNumLabels="2000" fontMinPixelSize="3"/>
       <dd_properties>
         <Option type="Map">
-          <Option type="QString" value="" name="name"/>
+          <Option value="" type="QString" name="name"/>
           <Option name="properties"/>
-          <Option type="QString" value="collection" name="type"/>
+          <Option value="collection" type="QString" name="type"/>
         </Option>
       </dd_properties>
       <callout type="simple">
         <Option type="Map">
-          <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
-          <Option type="int" value="0" name="blendMode"/>
+          <Option value="pole_of_inaccessibility" type="QString" name="anchorPoint"/>
+          <Option value="0" type="int" name="blendMode"/>
           <Option type="Map" name="ddProperties">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
-          <Option type="bool" value="false" name="drawToAllParts"/>
-          <Option type="QString" value="0" name="enabled"/>
-          <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
-          <Option type="QString" value="&lt;symbol alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; type=&quot;line&quot; is_animated=&quot;0&quot; force_rhr=&quot;0&quot; name=&quot;symbol&quot; frame_rate=&quot;10&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; locked=&quot;0&quot; id=&quot;{46476e7a-7f59-4bbd-97a0-c00abd534513}&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
-          <Option type="double" value="0" name="minLength"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
-          <Option type="QString" value="MM" name="minLengthUnit"/>
-          <Option type="double" value="0" name="offsetFromAnchor"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
-          <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
-          <Option type="double" value="0" name="offsetFromLabel"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
-          <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
+          <Option value="false" type="bool" name="drawToAllParts"/>
+          <Option value="0" type="QString" name="enabled"/>
+          <Option value="point_on_exterior" type="QString" name="labelAnchorPoint"/>
+          <Option value="&lt;symbol alpha=&quot;1&quot; frame_rate=&quot;10&quot; force_rhr=&quot;0&quot; type=&quot;line&quot; is_animated=&quot;0&quot; name=&quot;symbol&quot; clip_to_extent=&quot;1&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; type=&quot;QString&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; type=&quot;QString&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer class=&quot;SimpleLine&quot; locked=&quot;0&quot; pass=&quot;0&quot; enabled=&quot;1&quot; id=&quot;{46476e7a-7f59-4bbd-97a0-c00abd534513}&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option value=&quot;square&quot; type=&quot;QString&quot; name=&quot;capstyle&quot;/>&lt;Option value=&quot;5;2&quot; type=&quot;QString&quot; name=&quot;customdash&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;customdash_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option value=&quot;bevel&quot; type=&quot;QString&quot; name=&quot;joinstyle&quot;/>&lt;Option value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; type=&quot;QString&quot; name=&quot;line_color&quot;/>&lt;Option value=&quot;solid&quot; type=&quot;QString&quot; name=&quot;line_style&quot;/>&lt;Option value=&quot;0.3&quot; type=&quot;QString&quot; name=&quot;line_width&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;line_width_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;offset&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;offset_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;ring_filter&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;trim_distance_end&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;trim_distance_start&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option value=&quot;MM&quot; type=&quot;QString&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option value=&quot;0&quot; type=&quot;QString&quot; name=&quot;use_custom_dash&quot;/>&lt;Option value=&quot;3x:0,0,0,0,0,0&quot; type=&quot;QString&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option value=&quot;&quot; type=&quot;QString&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option value=&quot;collection&quot; type=&quot;QString&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" type="QString" name="lineSymbol"/>
+          <Option value="0" type="double" name="minLength"/>
+          <Option value="3x:0,0,0,0,0,0" type="QString" name="minLengthMapUnitScale"/>
+          <Option value="MM" type="QString" name="minLengthUnit"/>
+          <Option value="0" type="double" name="offsetFromAnchor"/>
+          <Option value="3x:0,0,0,0,0,0" type="QString" name="offsetFromAnchorMapUnitScale"/>
+          <Option value="MM" type="QString" name="offsetFromAnchorUnit"/>
+          <Option value="0" type="double" name="offsetFromLabel"/>
+          <Option value="3x:0,0,0,0,0,0" type="QString" name="offsetFromLabelMapUnitScale"/>
+          <Option value="MM" type="QString" name="offsetFromLabelUnit"/>
         </Option>
       </callout>
     </settings>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option type="QString" value="copy" name="QFieldSync/action"/>
-      <Option type="QString" value="{}" name="QFieldSync/attachment_naming"/>
-      <Option type="QString" value="offline" name="QFieldSync/cloud_action"/>
-      <Option type="QString" value="" name="QFieldSync/geometry_locked_expression"/>
-      <Option type="QString" value="{}" name="QFieldSync/photo_naming"/>
-      <Option type="QString" value="{}" name="QFieldSync/relationship_maximum_visible"/>
-      <Option type="int" value="30" name="QFieldSync/tracking_distance_requirement_minimum_meters"/>
-      <Option type="int" value="1" name="QFieldSync/tracking_erroneous_distance_safeguard_maximum_meters"/>
-      <Option type="int" value="0" name="QFieldSync/tracking_measurement_type"/>
-      <Option type="int" value="30" name="QFieldSync/tracking_time_requirement_interval_seconds"/>
-      <Option type="int" value="0" name="QFieldSync/value_map_button_interface_threshold"/>
-      <Option type="List" name="dualview/previewExpressions">
-        <Option type="QString" value="&quot;fonte_proc&quot;"/>
-      </Option>
-      <Option type="int" value="0" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
-        <Option type="QString" value="pzp_layer"/>
-        <Option type="QString" value="pzp_process"/>
-      </Option>
-      <Option type="StringList" name="variableValues">
-        <Option type="QString" value="danger_zones"/>
-        <Option type="QString" value="3000"/>
-      </Option>
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>0.7</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-    <DiagramCategory spacingUnit="MM" labelPlacementMethod="XHeight" penAlpha="255" backgroundAlpha="255" barWidth="5" direction="0" lineSizeScale="3x:0,0,0,0,0,0" penColor="#000000" scaleDependency="Area" rotationOffset="270" height="15" enabled="0" maxScaleDenominator="0" spacing="5" diagramOrientation="Up" backgroundColor="#ffffff" lineSizeType="MM" width="15" penWidth="0" spacingUnitScale="3x:0,0,0,0,0,0" opacity="1" showAxis="1" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" minimumSize="0" minScaleDenominator="0" scaleBasedVisibility="0">
-      <fontProperties italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
-      <attribute label="" field="" color="#000000" colorOpacity="1"/>
+  <LinearlyInterpolatedDiagramRenderer classificationAttributeExpression="" upperValue="0" lowerWidth="0" lowerHeight="0" upperWidth="5" upperHeight="5" attributeLegend="1" lowerValue="0" diagramType="Histogram">
+    <DiagramCategory minScaleDenominator="0" sizeScale="3x:0,0,0,0,0,0" spacing="5" maxScaleDenominator="0" backgroundColor="#ffffff" sizeType="MM" barWidth="5" direction="0" width="15" scaleBasedVisibility="0" spacingUnit="MM" stackedDiagramSpacingUnit="MM" enabled="0" opacity="1" penColor="#000000" stackedDiagramSpacing="0" height="15" rotationOffset="270" showAxis="1" penWidth="0" lineSizeScale="3x:0,0,0,0,0,0" minimumSize="0" penAlpha="255" lineSizeType="MM" spacingUnitScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" stackedDiagramSpacingUnitScale="3x:0,0,0,0,0,0" diagramOrientation="Up" stackedDiagramMode="Horizontal" scaleDependency="Area" backgroundAlpha="255">
+      <fontProperties bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
+      <attribute color="#000000" colorOpacity="1" field="" label=""/>
       <axisSymbol>
-        <symbol alpha="1" clip_to_extent="1" type="line" is_animated="0" force_rhr="0" name="" frame_rate="10">
+        <symbol alpha="1" frame_rate="10" force_rhr="0" type="line" is_animated="0" name="" clip_to_extent="1">
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
-          <layer class="SimpleLine" locked="0" id="{d1f09c07-43ff-4499-92ee-b0c16c4c6d2d}" enabled="1" pass="0">
+          <layer class="SimpleLine" locked="0" pass="0" enabled="1" id="{d1f09c07-43ff-4499-92ee-b0c16c4c6d2d}">
             <Option type="Map">
-              <Option type="QString" value="0" name="align_dash_pattern"/>
-              <Option type="QString" value="square" name="capstyle"/>
-              <Option type="QString" value="5;2" name="customdash"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-              <Option type="QString" value="MM" name="customdash_unit"/>
-              <Option type="QString" value="0" name="dash_pattern_offset"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-              <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-              <Option type="QString" value="0" name="draw_inside_polygon"/>
-              <Option type="QString" value="bevel" name="joinstyle"/>
-              <Option type="QString" value="35,35,35,255" name="line_color"/>
-              <Option type="QString" value="solid" name="line_style"/>
-              <Option type="QString" value="0.26" name="line_width"/>
-              <Option type="QString" value="MM" name="line_width_unit"/>
-              <Option type="QString" value="0" name="offset"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-              <Option type="QString" value="MM" name="offset_unit"/>
-              <Option type="QString" value="0" name="ring_filter"/>
-              <Option type="QString" value="0" name="trim_distance_end"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-              <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-              <Option type="QString" value="0" name="trim_distance_start"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-              <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-              <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-              <Option type="QString" value="0" name="use_custom_dash"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              <Option value="0" type="QString" name="align_dash_pattern"/>
+              <Option value="square" type="QString" name="capstyle"/>
+              <Option value="5;2" type="QString" name="customdash"/>
+              <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+              <Option value="MM" type="QString" name="customdash_unit"/>
+              <Option value="0" type="QString" name="dash_pattern_offset"/>
+              <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+              <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+              <Option value="0" type="QString" name="draw_inside_polygon"/>
+              <Option value="bevel" type="QString" name="joinstyle"/>
+              <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" type="QString" name="line_color"/>
+              <Option value="solid" type="QString" name="line_style"/>
+              <Option value="0.26" type="QString" name="line_width"/>
+              <Option value="MM" type="QString" name="line_width_unit"/>
+              <Option value="0" type="QString" name="offset"/>
+              <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+              <Option value="MM" type="QString" name="offset_unit"/>
+              <Option value="0" type="QString" name="ring_filter"/>
+              <Option value="0" type="QString" name="trim_distance_end"/>
+              <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+              <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+              <Option value="0" type="QString" name="trim_distance_start"/>
+              <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+              <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+              <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+              <Option value="0" type="QString" name="use_custom_dash"/>
+              <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
             </Option>
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option value="" type="QString" name="name"/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option value="collection" type="QString" name="type"/>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
       </axisSymbol>
     </DiagramCategory>
-  </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings showAll="1" linePlacementFlags="18" placement="1" obstacle="0" dist="0" priority="0" zIndex="0">
+  </LinearlyInterpolatedDiagramRenderer>
+  <DiagramLayerSettings placement="1" zIndex="0" obstacle="0" priority="0" dist="0" linePlacementFlags="18" showAll="1">
     <properties>
       <Option type="Map">
-        <Option type="QString" value="" name="name"/>
+        <Option value="" type="QString" name="name"/>
         <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
+        <Option value="collection" type="QString" name="type"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="1" geometryPrecision="0.001">
+  <geometryOptions geometryPrecision="0.001" removeDuplicateNodes="1">
     <activeChecks type="StringList">
-      <Option type="QString" value="QgsIsValidCheck"/>
+      <Option value="QgsIsValidCheck" type="QString"/>
     </activeChecks>
     <checkConfiguration type="Map">
       <Option type="Map" name="QgsGeometryGapCheck">
-        <Option type="double" value="0" name="allowedGapsBuffer"/>
-        <Option type="bool" value="false" name="allowedGapsEnabled"/>
-        <Option type="QString" value="" name="allowedGapsLayer"/>
+        <Option value="0" type="double" name="allowedGapsBuffer"/>
+        <Option value="false" type="bool" name="allowedGapsEnabled"/>
+        <Option value="" type="QString" name="allowedGapsLayer"/>
       </Option>
     </checkConfiguration>
   </geometryOptions>
-  <legend type="default-vector" showLabelLegend="0"/>
+  <legend showLabelLegend="0" type="default-vector"/>
   <referencedLayers/>
   <fieldConfiguration>
     <field configurationFlags="NoFlag" name="fid">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -810,19 +790,19 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" value="1000" name="molto bassa"/>
+                <Option value="1000" type="QString" name="molto bassa"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1001" name="bassa"/>
+                <Option value="1001" type="QString" name="bassa"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1002" name="media"/>
+                <Option value="1002" type="QString" name="media"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1003" name="alta"/>
+                <Option value="1003" type="QString" name="alta"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>"/>
+                <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" type="QString" name="&lt;NULL>"/>
               </Option>
             </Option>
           </Option>
@@ -835,22 +815,22 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" value="1000" name="nessun_impatto"/>
+                <Option value="1000" type="QString" name="nessun_impatto"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1001" name="impatto_presente"/>
+                <Option value="1001" type="QString" name="impatto_presente"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1002" name="debole"/>
+                <Option value="1002" type="QString" name="debole"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1003" name="medio"/>
+                <Option value="1003" type="QString" name="medio"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1004" name="forte"/>
+                <Option value="1004" type="QString" name="forte"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>"/>
+                <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" type="QString" name="&lt;NULL>"/>
               </Option>
             </Option>
           </Option>
@@ -861,19 +841,19 @@
       <editWidget type="ValueRelation">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="AllowMulti"/>
-            <Option type="bool" value="false" name="AllowNull"/>
-            <Option type="QString" value="Case&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 0 then 'Sconosciuto'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1001 then 'Scenario puntuale'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1000 then 'Scenario diffuso'&#xd;&#xa;&#x9;else '_'&#xd;&#xa;End" name="Description"/>
-            <Option type="QString" value="" name="FilterExpression"/>
-            <Option type="QString" value="fonte_proc" name="Key"/>
-            <Option type="QString" value="Zona_sorgente__fonte_processo__5b9d7400_b480_4544_b701_66f3d70b7b75" name="Layer"/>
-            <Option type="QString" value="Zona sorgente (fonte processo)" name="LayerName"/>
-            <Option type="QString" value="ogr" name="LayerProviderName"/>
-            <Option type="QString" value="F:\UPIP\06_StrumentiGis\02_Progetti base\09_Plugin QGIS\01_Test QGIS\Test plugin vers. 1.4.4\data_3000_25032025_142655.gpkg|layername=Zona sorgente (fonte processo)" name="LayerSource"/>
-            <Option type="int" value="1" name="NofColumns"/>
-            <Option type="bool" value="false" name="OrderByValue"/>
-            <Option type="bool" value="false" name="UseCompleter"/>
-            <Option type="QString" value="fonte_proc" name="Value"/>
+            <Option value="false" type="bool" name="AllowMulti"/>
+            <Option value="false" type="bool" name="AllowNull"/>
+            <Option value="Case&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 0 then 'Sconosciuto'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1001 then 'Scenario puntuale'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1000 then 'Scenario diffuso'&#xd;&#xa;&#x9;else '_'&#xd;&#xa;End" type="QString" name="Description"/>
+            <Option type="invalid" name="FilterExpression"/>
+            <Option value="fonte_proc" type="QString" name="Key"/>
+            <Option value="Zona_sorgente__fonte_processo__5b9d7400_b480_4544_b701_66f3d70b7b75" type="QString" name="Layer"/>
+            <Option value="Zona sorgente (fonte processo)" type="QString" name="LayerName"/>
+            <Option value="ogr" type="QString" name="LayerProviderName"/>
+            <Option value="F:\UPIP\06_StrumentiGis\02_Progetti base\09_Plugin QGIS\01_Test QGIS\Test plugin vers. 1.4.4\data_3000_25032025_142655.gpkg|layername=Zona sorgente (fonte processo)" type="QString" name="LayerSource"/>
+            <Option value="1" type="int" name="NofColumns"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="UseCompleter"/>
+            <Option value="fonte_proc" type="QString" name="Value"/>
           </Option>
         </config>
       </editWidget>
@@ -884,7 +864,7 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" value="3000" name="Caduta sassi o blocchi"/>
+                <Option value="3000" type="QString" name="Caduta sassi o blocchi"/>
               </Option>
             </Option>
           </Option>
@@ -895,8 +875,18 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field configurationFlags="NoFlag" name="area">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -905,8 +895,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
@@ -917,22 +907,22 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" value="1000" name="non_in_pericolo"/>
+                <Option value="1000" type="QString" name="non_in_pericolo"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1001" name="pericolo_residuo"/>
+                <Option value="1001" type="QString" name="pericolo_residuo"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1002" name="basso"/>
+                <Option value="1002" type="QString" name="basso"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1003" name="medio"/>
+                <Option value="1003" type="QString" name="medio"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1004" name="elevato"/>
+                <Option value="1004" type="QString" name="elevato"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>"/>
+                <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" type="QString" name="&lt;NULL>"/>
               </Option>
             </Option>
           </Option>
@@ -945,40 +935,40 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
-                <Option type="QString" value="1000" name="0"/>
+                <Option value="1000" type="QString" name="0"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1001" name="9"/>
+                <Option value="1001" type="QString" name="9"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1002" name="8"/>
+                <Option value="1002" type="QString" name="8"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1003" name="7"/>
+                <Option value="1003" type="QString" name="7"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1004" name="6"/>
+                <Option value="1004" type="QString" name="6"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1005" name="5"/>
+                <Option value="1005" type="QString" name="5"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1006" name="4"/>
+                <Option value="1006" type="QString" name="4"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1007" name="3"/>
+                <Option value="1007" type="QString" name="3"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1008" name="2"/>
+                <Option value="1008" type="QString" name="2"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1009" name="1"/>
+                <Option value="1009" type="QString" name="1"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1010" name="-10"/>
+                <Option value="1010" type="QString" name="-10"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>"/>
+                <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" type="QString" name="&lt;NULL>"/>
               </Option>
             </Option>
           </Option>
@@ -999,16 +989,6 @@
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="area">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
   </fieldConfiguration>
   <aliases>
     <alias index="0" field="fid" name="Identificativo"/>
@@ -1017,90 +997,104 @@
     <alias index="3" field="fonte_proc" name="Fonte processo"/>
     <alias index="4" field="proc_parz" name="Processo"/>
     <alias index="5" field="commento" name="Commento"/>
-    <alias index="6" field="periodo_ritorno" name="Periodo di ritorno"/>
-    <alias index="7" field="grado_pericolo" name="Grado pericolo"/>
-    <alias index="8" field="matrice" name="Matrice"/>
-    <alias index="9" field="layer" name=""/>
-    <alias index="10" field="path" name=""/>
-    <alias index="11" field="area" name="Area"/>
+    <alias index="6" field="area" name="Area"/>
+    <alias index="7" field="periodo_ritorno" name="Periodo di ritorno"/>
+    <alias index="8" field="grado_pericolo" name="Grado pericolo"/>
+    <alias index="9" field="matrice" name="Matrice"/>
+    <alias index="10" field="layer" name=""/>
+    <alias index="11" field="path" name=""/>
   </aliases>
   <splitPolicies>
-    <policy policy="Duplicate" field="fid"/>
-    <policy policy="Duplicate" field="prob_rottura"/>
-    <policy policy="Duplicate" field="classe_intensita"/>
-    <policy policy="Duplicate" field="fonte_proc"/>
-    <policy policy="Duplicate" field="proc_parz"/>
-    <policy policy="Duplicate" field="commento"/>
-    <policy policy="Duplicate" field="periodo_ritorno"/>
-    <policy policy="Duplicate" field="grado_pericolo"/>
-    <policy policy="Duplicate" field="matrice"/>
-    <policy policy="Duplicate" field="layer"/>
-    <policy policy="Duplicate" field="path"/>
-    <policy policy="Duplicate" field="area"/>
+    <policy field="fid" policy="Duplicate"/>
+    <policy field="prob_rottura" policy="Duplicate"/>
+    <policy field="classe_intensita" policy="Duplicate"/>
+    <policy field="fonte_proc" policy="Duplicate"/>
+    <policy field="proc_parz" policy="Duplicate"/>
+    <policy field="commento" policy="Duplicate"/>
+    <policy field="area" policy="Duplicate"/>
+    <policy field="periodo_ritorno" policy="Duplicate"/>
+    <policy field="grado_pericolo" policy="Duplicate"/>
+    <policy field="matrice" policy="Duplicate"/>
+    <policy field="layer" policy="Duplicate"/>
+    <policy field="path" policy="Duplicate"/>
   </splitPolicies>
+  <duplicatePolicies>
+    <policy field="fid" policy="Duplicate"/>
+    <policy field="prob_rottura" policy="Duplicate"/>
+    <policy field="classe_intensita" policy="Duplicate"/>
+    <policy field="fonte_proc" policy="Duplicate"/>
+    <policy field="proc_parz" policy="Duplicate"/>
+    <policy field="commento" policy="Duplicate"/>
+    <policy field="area" policy="Duplicate"/>
+    <policy field="periodo_ritorno" policy="Duplicate"/>
+    <policy field="grado_pericolo" policy="Duplicate"/>
+    <policy field="matrice" policy="Duplicate"/>
+    <policy field="layer" policy="Duplicate"/>
+    <policy field="path" policy="Duplicate"/>
+  </duplicatePolicies>
   <defaults>
-    <default field="fid" applyOnUpdate="0" expression=""/>
-    <default field="prob_rottura" applyOnUpdate="0" expression=""/>
-    <default field="classe_intensita" applyOnUpdate="0" expression=""/>
-    <default field="fonte_proc" applyOnUpdate="0" expression=""/>
-    <default field="proc_parz" applyOnUpdate="0" expression=""/>
-    <default field="commento" applyOnUpdate="0" expression=""/>
-    <default field="periodo_ritorno" applyOnUpdate="0" expression=""/>
-    <default field="grado_pericolo" applyOnUpdate="0" expression=""/>
-    <default field="matrice" applyOnUpdate="0" expression=""/>
-    <default field="layer" applyOnUpdate="0" expression=""/>
-    <default field="path" applyOnUpdate="0" expression=""/>
-    <default field="area" applyOnUpdate="0" expression=""/>
+    <default field="fid" expression="" applyOnUpdate="0"/>
+    <default field="prob_rottura" expression="" applyOnUpdate="0"/>
+    <default field="classe_intensita" expression="" applyOnUpdate="0"/>
+    <default field="fonte_proc" expression="" applyOnUpdate="0"/>
+    <default field="proc_parz" expression="" applyOnUpdate="0"/>
+    <default field="commento" expression="" applyOnUpdate="0"/>
+    <default field="area" expression="" applyOnUpdate="0"/>
+    <default field="periodo_ritorno" expression="" applyOnUpdate="0"/>
+    <default field="grado_pericolo" expression="" applyOnUpdate="0"/>
+    <default field="matrice" expression="" applyOnUpdate="0"/>
+    <default field="layer" expression="" applyOnUpdate="0"/>
+    <default field="path" expression="" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint constraints="3" unique_strength="1" field="fid" notnull_strength="1" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="prob_rottura" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="classe_intensita" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="fonte_proc" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="proc_parz" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="commento" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="periodo_ritorno" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="grado_pericolo" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="matrice" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="layer" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="path" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="area" notnull_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="1" constraints="3" field="fid" unique_strength="1" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="prob_rottura" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="classe_intensita" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="fonte_proc" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="proc_parz" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="commento" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="area" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="periodo_ritorno" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="grado_pericolo" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="matrice" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="layer" unique_strength="0" exp_strength="0"/>
+    <constraint notnull_strength="0" constraints="0" field="path" unique_strength="0" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="fid" exp="" desc=""/>
-    <constraint field="prob_rottura" exp="" desc=""/>
-    <constraint field="classe_intensita" exp="" desc=""/>
-    <constraint field="fonte_proc" exp="" desc=""/>
-    <constraint field="proc_parz" exp="" desc=""/>
-    <constraint field="commento" exp="" desc=""/>
-    <constraint field="periodo_ritorno" exp="" desc=""/>
-    <constraint field="grado_pericolo" exp="" desc=""/>
-    <constraint field="matrice" exp="" desc=""/>
-    <constraint field="layer" exp="" desc=""/>
-    <constraint field="path" exp="" desc=""/>
-    <constraint field="area" exp="" desc=""/>
+    <constraint field="fid" desc="" exp=""/>
+    <constraint field="prob_rottura" desc="" exp=""/>
+    <constraint field="classe_intensita" desc="" exp=""/>
+    <constraint field="fonte_proc" desc="" exp=""/>
+    <constraint field="proc_parz" desc="" exp=""/>
+    <constraint field="commento" desc="" exp=""/>
+    <constraint field="area" desc="" exp=""/>
+    <constraint field="periodo_ritorno" desc="" exp=""/>
+    <constraint field="grado_pericolo" desc="" exp=""/>
+    <constraint field="matrice" desc="" exp=""/>
+    <constraint field="layer" desc="" exp=""/>
+    <constraint field="path" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields>
-    <field precision="0" length="-1" subType="0" type="6" comment="" expression=" $area " name="area" typeName="double precision"/>
+    <field length="-1" subType="0" typeName="double precision" precision="0" type="6" expression=" $area " comment="" name="area"/>
   </expressionfields>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="&quot;matrice&quot;" sortOrder="0">
+  <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="&quot;matrice&quot;">
     <columns>
-      <column type="field" name="fonte_proc" width="-1" hidden="0"/>
-      <column type="field" name="grado_pericolo" width="-1" hidden="0"/>
-      <column type="field" name="matrice" width="-1" hidden="0"/>
-      <column type="field" name="commento" width="-1" hidden="0"/>
-      <column type="field" name="proc_parz" width="268" hidden="0"/>
-      <column type="field" name="fid" width="-1" hidden="0"/>
-      <column type="field" name="area" width="-1" hidden="0"/>
-      <column type="field" name="classe_intensita" width="-1" hidden="0"/>
-      <column type="field" name="periodo_ritorno" width="-1" hidden="0"/>
-      <column type="field" name="prob_rottura" width="-1" hidden="0"/>
-      <column type="field" name="layer" width="-1" hidden="1"/>
-      <column type="field" name="path" width="-1" hidden="1"/>
-      <column type="actions" width="-1" hidden="1"/>
+      <column hidden="0" width="-1" type="field" name="fonte_proc"/>
+      <column hidden="0" width="-1" type="field" name="grado_pericolo"/>
+      <column hidden="0" width="-1" type="field" name="matrice"/>
+      <column hidden="0" width="-1" type="field" name="commento"/>
+      <column hidden="0" width="268" type="field" name="proc_parz"/>
+      <column hidden="0" width="-1" type="field" name="fid"/>
+      <column hidden="0" width="-1" type="field" name="area"/>
+      <column hidden="0" width="-1" type="field" name="classe_intensita"/>
+      <column hidden="0" width="-1" type="field" name="periodo_ritorno"/>
+      <column hidden="0" width="-1" type="field" name="prob_rottura"/>
+      <column hidden="1" width="-1" type="field" name="layer"/>
+      <column hidden="1" width="-1" type="field" name="path"/>
+      <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -1132,70 +1126,70 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-      <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+    <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="">
+      <labelFont bold="0" underline="0" description="Ubuntu Sans,11,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
     </labelStyle>
-    <attributeEditorContainer collapsed="0" visibilityExpressionEnabled="0" showLabel="1" type="Tab" collapsedExpressionEnabled="0" verticalStretch="0" groupBox="0" collapsedExpression="" visibilityExpression="" name="Attributi" horizontalStretch="0" columnCount="1">
-      <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-        <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+    <attributeEditorContainer collapsedExpression="" visibilityExpression="" columnCount="1" showLabel="1" horizontalStretch="0" type="Tab" groupBox="0" visibilityExpressionEnabled="0" verticalStretch="0" collapsedExpressionEnabled="0" collapsed="0" name="Attributi">
+      <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+        <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
       </labelStyle>
-      <attributeEditorField showLabel="1" index="3" verticalStretch="0" name="fonte_proc" horizontalStretch="0">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorField index="3" showLabel="1" horizontalStretch="0" verticalStretch="0" name="fonte_proc">
+        <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField showLabel="1" index="7" verticalStretch="0" name="grado_pericolo" horizontalStretch="0">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorField index="8" showLabel="1" horizontalStretch="0" verticalStretch="0" name="grado_pericolo">
+        <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField showLabel="1" index="8" verticalStretch="0" name="matrice" horizontalStretch="0">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorField index="9" showLabel="1" horizontalStretch="0" verticalStretch="0" name="matrice">
+        <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField showLabel="1" index="5" verticalStretch="0" name="commento" horizontalStretch="0">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorField index="5" showLabel="1" horizontalStretch="0" verticalStretch="0" name="commento">
+        <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorContainer collapsed="0" visibilityExpressionEnabled="0" showLabel="1" type="GroupBox" collapsedExpressionEnabled="0" verticalStretch="0" groupBox="1" collapsedExpression="" visibilityExpression="" name="Sistema (automatico)" horizontalStretch="0" columnCount="1">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorContainer collapsedExpression="" visibilityExpression="" columnCount="1" showLabel="1" horizontalStretch="0" type="GroupBox" groupBox="1" visibilityExpressionEnabled="0" verticalStretch="0" collapsedExpressionEnabled="0" collapsed="0" name="Sistema (automatico)">
+        <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
         </labelStyle>
-        <attributeEditorField showLabel="1" index="4" verticalStretch="0" name="proc_parz" horizontalStretch="0">
-          <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-            <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+        <attributeEditorField index="4" showLabel="1" horizontalStretch="0" verticalStretch="0" name="proc_parz">
+          <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+            <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField showLabel="1" index="0" verticalStretch="0" name="fid" horizontalStretch="0">
-          <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-            <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+        <attributeEditorField index="0" showLabel="1" horizontalStretch="0" verticalStretch="0" name="fid">
+          <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+            <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField showLabel="1" index="11" verticalStretch="0" name="area" horizontalStretch="0">
-          <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-            <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+        <attributeEditorField index="6" showLabel="1" horizontalStretch="0" verticalStretch="0" name="area">
+          <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+            <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
           </labelStyle>
         </attributeEditorField>
       </attributeEditorContainer>
-      <attributeEditorContainer collapsed="0" visibilityExpressionEnabled="0" showLabel="1" type="GroupBox" collapsedExpressionEnabled="0" verticalStretch="0" groupBox="1" collapsedExpression="" visibilityExpression="" name="Storico (campi ereditati dai layer precedenti)" horizontalStretch="0" columnCount="1">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorContainer collapsedExpression="" visibilityExpression="" columnCount="1" showLabel="1" horizontalStretch="0" type="GroupBox" groupBox="1" visibilityExpressionEnabled="0" verticalStretch="0" collapsedExpressionEnabled="0" collapsed="0" name="Storico (campi ereditati dai layer precedenti)">
+        <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
         </labelStyle>
-        <attributeEditorField showLabel="1" index="1" verticalStretch="0" name="prob_rottura" horizontalStretch="0">
-          <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-            <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+        <attributeEditorField index="1" showLabel="1" horizontalStretch="0" verticalStretch="0" name="prob_rottura">
+          <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+            <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField showLabel="1" index="6" verticalStretch="0" name="periodo_ritorno" horizontalStretch="0">
-          <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-            <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+        <attributeEditorField index="7" showLabel="1" horizontalStretch="0" verticalStretch="0" name="periodo_ritorno">
+          <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+            <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField showLabel="1" index="2" verticalStretch="0" name="classe_intensita" horizontalStretch="0">
-          <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-            <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+        <attributeEditorField index="2" showLabel="1" horizontalStretch="0" verticalStretch="0" name="classe_intensita">
+          <labelStyle overrideLabelColor="0" overrideLabelFont="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+            <labelFont bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" italic="0"/>
           </labelStyle>
         </attributeEditorField>
       </attributeEditorContainer>
@@ -1221,23 +1215,23 @@ def my_form_open(dialog, layer, feature):
     <field editable="1" name="scala"/>
   </editable>
   <labelOnTop>
-    <field name="area" labelOnTop="0"/>
-    <field name="area in m2" labelOnTop="0"/>
-    <field name="classe_intensita" labelOnTop="0"/>
-    <field name="commento" labelOnTop="0"/>
-    <field name="fid" labelOnTop="0"/>
-    <field name="fonte_proc" labelOnTop="0"/>
-    <field name="grado_pericolo" labelOnTop="0"/>
-    <field name="layer" labelOnTop="0"/>
-    <field name="liv_dettaglio" labelOnTop="0"/>
-    <field name="matrice" labelOnTop="0"/>
-    <field name="osservazioni" labelOnTop="0"/>
-    <field name="path" labelOnTop="0"/>
-    <field name="periodo_ritorno" labelOnTop="0"/>
-    <field name="prob_rottura" labelOnTop="0"/>
-    <field name="proc_parz" labelOnTop="0"/>
-    <field name="proc_parz_ch" labelOnTop="0"/>
-    <field name="scala" labelOnTop="0"/>
+    <field labelOnTop="0" name="area"/>
+    <field labelOnTop="0" name="area in m2"/>
+    <field labelOnTop="0" name="classe_intensita"/>
+    <field labelOnTop="0" name="commento"/>
+    <field labelOnTop="0" name="fid"/>
+    <field labelOnTop="0" name="fonte_proc"/>
+    <field labelOnTop="0" name="grado_pericolo"/>
+    <field labelOnTop="0" name="layer"/>
+    <field labelOnTop="0" name="liv_dettaglio"/>
+    <field labelOnTop="0" name="matrice"/>
+    <field labelOnTop="0" name="osservazioni"/>
+    <field labelOnTop="0" name="path"/>
+    <field labelOnTop="0" name="periodo_ritorno"/>
+    <field labelOnTop="0" name="prob_rottura"/>
+    <field labelOnTop="0" name="proc_parz"/>
+    <field labelOnTop="0" name="proc_parz_ch"/>
+    <field labelOnTop="0" name="scala"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="area"/>

--- a/pzp/qml/intensity.qml
+++ b/pzp/qml/intensity.qml
@@ -1,415 +1,415 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyAlgorithm="0" version="3.34.9-Prizren" labelsEnabled="0" minScale="0" readOnly="0" styleCategories="AllStyleCategories" maxScale="0" simplifyLocal="1" symbologyReferenceScale="-1">
+<qgis simplifyLocal="1" symbologyReferenceScale="-1" labelsEnabled="0" simplifyDrawingTol="1" simplifyMaxScale="1" maxScale="0" autoRefreshTime="0" hasScaleBasedVisibilityFlag="0" readOnly="0" styleCategories="LayerConfiguration|Symbology|Symbology3D|Labeling|Fields|Forms|Actions|MapTips|Diagrams|AttributeTable|Rendering|GeometryOptions|Relations|Temporal|Legend|Elevation|Notes" minScale="0" autoRefreshMode="Disabled" simplifyDrawingHints="1" version="3.43.0-Master" simplifyAlgorithm="0">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <temporal limitMode="0" endField="" accumulate="0" startField="" startExpression="" endExpression="" enabled="0" fixedDuration="0" mode="0" durationUnit="min" durationField="fid">
+  <temporal endField="" endExpression="" startExpression="" durationField="fid" startField="" enabled="0" mode="0" fixedDuration="0" durationUnit="min" accumulate="0" limitMode="0">
     <fixedRange>
       <start></start>
       <end></end>
     </fixedRange>
   </temporal>
-  <elevation binding="Centroid" type="IndividualFeatures" zoffset="0" extrusionEnabled="0" zscale="1" symbology="Line" showMarkerSymbolInSurfacePlots="0" respectLayerSymbol="1" extrusion="0" clamping="Terrain">
+  <elevation binding="Centroid" zscale="1" extrusionEnabled="0" zoffset="0" respectLayerSymbol="1" customToleranceEnabled="0" extrusion="0" symbology="Line" clamping="Terrain" showMarkerSymbolInSurfacePlots="0" type="IndividualFeatures">
     <data-defined-properties>
       <Option type="Map">
-        <Option type="QString" value="" name="name"/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </data-defined-properties>
     <profileLineSymbol>
-      <symbol alpha="1" clip_to_extent="1" type="line" is_animated="0" force_rhr="0" name="" frame_rate="10">
+      <symbol name="" alpha="1" frame_rate="10" force_rhr="0" is_animated="0" type="line" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleLine" locked="0" id="{99ad771e-232d-48e9-8021-298b9581ce7a}" enabled="1" pass="0">
+        <layer pass="0" locked="0" id="{99ad771e-232d-48e9-8021-298b9581ce7a}" class="SimpleLine" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="0" name="align_dash_pattern"/>
-            <Option type="QString" value="square" name="capstyle"/>
-            <Option type="QString" value="5;2" name="customdash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-            <Option type="QString" value="MM" name="customdash_unit"/>
-            <Option type="QString" value="0" name="dash_pattern_offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-            <Option type="QString" value="0" name="draw_inside_polygon"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="196,60,57,255" name="line_color"/>
-            <Option type="QString" value="solid" name="line_style"/>
-            <Option type="QString" value="0.6" name="line_width"/>
-            <Option type="QString" value="MM" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="0" name="trim_distance_end"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-            <Option type="QString" value="0" name="trim_distance_start"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-            <Option type="QString" value="0" name="use_custom_dash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+            <Option value="0" name="align_dash_pattern" type="QString"/>
+            <Option value="square" name="capstyle" type="QString"/>
+            <Option value="5;2" name="customdash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+            <Option value="MM" name="customdash_unit" type="QString"/>
+            <Option value="0" name="dash_pattern_offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+            <Option value="0" name="draw_inside_polygon" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="196,60,57,255,rgb:0.7686274509803922,0.23529411764705882,0.22352941176470589,1" name="line_color" type="QString"/>
+            <Option value="solid" name="line_style" type="QString"/>
+            <Option value="0.6" name="line_width" type="QString"/>
+            <Option value="MM" name="line_width_unit" type="QString"/>
+            <Option value="0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0" name="ring_filter" type="QString"/>
+            <Option value="0" name="trim_distance_end" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+            <Option value="0" name="trim_distance_start" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+            <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+            <Option value="0" name="use_custom_dash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </profileLineSymbol>
     <profileFillSymbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="" frame_rate="10">
+      <symbol name="" alpha="1" frame_rate="10" force_rhr="0" is_animated="0" type="fill" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{64d13a55-2706-46ad-b1ac-a5bcdc09a925}" enabled="1" pass="0">
+        <layer pass="0" locked="0" id="{64d13a55-2706-46ad-b1ac-a5bcdc09a925}" class="SimpleFill" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="196,60,57,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="140,43,41,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.2" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="196,60,57,255,rgb:0.7686274509803922,0.23529411764705882,0.22352941176470589,1" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="140,43,41,255,rgb:0.5490196078431373,0.16862745098039217,0.16078431372549021,1" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.2" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </profileFillSymbol>
     <profileMarkerSymbol>
-      <symbol alpha="1" clip_to_extent="1" type="marker" is_animated="0" force_rhr="0" name="" frame_rate="10">
+      <symbol name="" alpha="1" frame_rate="10" force_rhr="0" is_animated="0" type="marker" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleMarker" locked="0" id="{55bb9cb8-f292-47ab-a32c-c71448a5b4a6}" enabled="1" pass="0">
+        <layer pass="0" locked="0" id="{55bb9cb8-f292-47ab-a32c-c71448a5b4a6}" class="SimpleMarker" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="0" name="angle"/>
-            <Option type="QString" value="square" name="cap_style"/>
-            <Option type="QString" value="196,60,57,255" name="color"/>
-            <Option type="QString" value="1" name="horizontal_anchor_point"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="diamond" name="name"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="140,43,41,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.2" name="outline_width"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="diameter" name="scale_method"/>
-            <Option type="QString" value="3" name="size"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
-            <Option type="QString" value="MM" name="size_unit"/>
-            <Option type="QString" value="1" name="vertical_anchor_point"/>
+            <Option value="0" name="angle" type="QString"/>
+            <Option value="square" name="cap_style" type="QString"/>
+            <Option value="196,60,57,255,rgb:0.7686274509803922,0.23529411764705882,0.22352941176470589,1" name="color" type="QString"/>
+            <Option value="1" name="horizontal_anchor_point" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="diamond" name="name" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="140,43,41,255,rgb:0.5490196078431373,0.16862745098039217,0.16078431372549021,1" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.2" name="outline_width" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="diameter" name="scale_method" type="QString"/>
+            <Option value="3" name="size" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+            <Option value="MM" name="size_unit" type="QString"/>
+            <Option value="1" name="vertical_anchor_point" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </profileMarkerSymbol>
   </elevation>
-  <renderer-v2 type="categorizedSymbol" attr="classe_intensita" symbollevels="1" enableorderby="0" forceraster="0" referencescale="-1">
+  <renderer-v2 symbollevels="1" attr="classe_intensita" referencescale="-1" enableorderby="0" forceraster="0" type="categorizedSymbol">
     <categories>
-      <category label="forte" type="string" uuid="0" render="true" symbol="0" value="1004"/>
-      <category label="medio" type="string" uuid="1" render="true" symbol="1" value="1003"/>
-      <category label="debole" type="string" uuid="2" render="true" symbol="2" value="1002"/>
-      <category label="impatto presente" type="string" uuid="3" render="true" symbol="3" value="1001"/>
-      <category label="nessun impatto" type="string" uuid="4" render="true" symbol="4" value="1000"/>
+      <category value="1004" uuid="0" label="forte" symbol="0" render="true" type="string"/>
+      <category value="1003" uuid="1" label="medio" symbol="1" render="true" type="string"/>
+      <category value="1002" uuid="2" label="debole" symbol="2" render="true" type="string"/>
+      <category value="1001" uuid="3" label="impatto presente" symbol="3" render="true" type="string"/>
+      <category value="1000" uuid="4" label="nessun impatto" symbol="4" render="true" type="string"/>
     </categories>
     <symbols>
-      <symbol alpha="0.8" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="0" frame_rate="10">
+      <symbol name="0" alpha="0.8" frame_rate="10" force_rhr="0" is_animated="0" type="fill" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{938ae1dc-3804-47a4-a1e8-6478d894b877}" enabled="1" pass="5">
+        <layer pass="5" locked="0" id="{938ae1dc-3804-47a4-a1e8-6478d894b877}" class="SimpleFill" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="56,158,0,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="130,130,130,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.2" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="56,158,0,255,rgb:0.2196078431372549,0.61960784313725492,0,1" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="130,130,130,255,rgb:0.50980392156862742,0.50980392156862742,0.50980392156862742,1" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.2" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="0.8" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="1" frame_rate="10">
+      <symbol name="1" alpha="0.8" frame_rate="10" force_rhr="0" is_animated="0" type="fill" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{1d281922-6f88-4805-aa25-4ae6802959ab}" enabled="1" pass="4">
+        <layer pass="4" locked="0" id="{1d281922-6f88-4805-aa25-4ae6802959ab}" class="SimpleFill" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="83,212,0,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="130,130,130,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.2" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="83,212,0,255,rgb:0.32549019607843138,0.83137254901960789,0,1" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="130,130,130,255,rgb:0.50980392156862742,0.50980392156862742,0.50980392156862742,1" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.2" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="0.8" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="2" frame_rate="10">
+      <symbol name="2" alpha="0.8" frame_rate="10" force_rhr="0" is_animated="0" type="fill" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{c67d46fc-6f66-42b3-aa50-ecf62f647636}" enabled="1" pass="3">
+        <layer pass="3" locked="0" id="{c67d46fc-6f66-42b3-aa50-ecf62f647636}" class="SimpleFill" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="209,255,115,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="130,130,130,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.2" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="209,255,115,255,rgb:0.81960784313725488,1,0.45098039215686275,1" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="130,130,130,255,rgb:0.50980392156862742,0.50980392156862742,0.50980392156862742,1" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.2" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="0.8" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="3" frame_rate="10">
+      <symbol name="3" alpha="0.8" frame_rate="10" force_rhr="0" is_animated="0" type="fill" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{733aadeb-15b3-4392-8042-54a246ad5354}" enabled="1" pass="2">
+        <layer pass="2" locked="0" id="{733aadeb-15b3-4392-8042-54a246ad5354}" class="SimpleFill" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="232,190,255,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="130,130,130,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.26" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="232,190,255,255,rgb:0.90980392156862744,0.74509803921568629,1,1" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="130,130,130,255,rgb:0.50980392156862742,0.50980392156862742,0.50980392156862742,1" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.26" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="0.8" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="4" frame_rate="10">
+      <symbol name="4" alpha="0.8" frame_rate="10" force_rhr="0" is_animated="0" type="fill" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="LinePatternFill" locked="0" id="{f9a42335-b95b-47e4-b5f9-50a024900737}" enabled="1" pass="1">
+        <layer pass="1" locked="0" id="{f9a42335-b95b-47e4-b5f9-50a024900737}" class="LinePatternFill" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="45" name="angle"/>
-            <Option type="QString" value="during_render" name="clip_mode"/>
-            <Option type="QString" value="121,125,127,201" name="color"/>
-            <Option type="QString" value="feature" name="coordinate_reference"/>
-            <Option type="QString" value="2.2" name="distance"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="distance_map_unit_scale"/>
-            <Option type="QString" value="MM" name="distance_unit"/>
-            <Option type="QString" value="1" name="line_width"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="line_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option value="45" name="angle" type="QString"/>
+            <Option value="during_render" name="clip_mode" type="QString"/>
+            <Option value="121,125,127,201,rgb:0.47450980392156861,0.49019607843137253,0.49803921568627452,0.78823529411764703" name="color" type="QString"/>
+            <Option value="feature" name="coordinate_reference" type="QString"/>
+            <Option value="2.2" name="distance" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="distance_map_unit_scale" type="QString"/>
+            <Option value="MM" name="distance_unit" type="QString"/>
+            <Option value="1" name="line_width" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="line_width_map_unit_scale" type="QString"/>
+            <Option value="MM" name="line_width_unit" type="QString"/>
+            <Option value="0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
-          <symbol alpha="1" clip_to_extent="1" type="line" is_animated="0" force_rhr="0" name="@4@0" frame_rate="10">
+          <symbol name="@4@0" alpha="1" frame_rate="10" force_rhr="0" is_animated="0" type="line" clip_to_extent="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleLine" locked="0" id="{5d034b08-90e3-4af0-846e-e99e34c63927}" enabled="1" pass="0">
+            <layer pass="0" locked="0" id="{5d034b08-90e3-4af0-846e-e99e34c63927}" class="SimpleLine" enabled="1">
               <Option type="Map">
-                <Option type="QString" value="0" name="align_dash_pattern"/>
-                <Option type="QString" value="square" name="capstyle"/>
-                <Option type="QString" value="5;2" name="customdash"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-                <Option type="QString" value="MM" name="customdash_unit"/>
-                <Option type="QString" value="0" name="dash_pattern_offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-                <Option type="QString" value="0" name="draw_inside_polygon"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="209,255,115,255" name="line_color"/>
-                <Option type="QString" value="solid" name="line_style"/>
-                <Option type="QString" value="0.2" name="line_width"/>
-                <Option type="QString" value="MM" name="line_width_unit"/>
-                <Option type="QString" value="0" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="offset_unit"/>
-                <Option type="QString" value="0" name="ring_filter"/>
-                <Option type="QString" value="0" name="trim_distance_end"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-                <Option type="QString" value="0" name="trim_distance_start"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-                <Option type="QString" value="0" name="use_custom_dash"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+                <Option value="0" name="align_dash_pattern" type="QString"/>
+                <Option value="square" name="capstyle" type="QString"/>
+                <Option value="5;2" name="customdash" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+                <Option value="MM" name="customdash_unit" type="QString"/>
+                <Option value="0" name="dash_pattern_offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+                <Option value="0" name="draw_inside_polygon" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="209,255,115,255,rgb:0.81960784313725488,1,0.45098039215686275,1" name="line_color" type="QString"/>
+                <Option value="solid" name="line_style" type="QString"/>
+                <Option value="0.2" name="line_width" type="QString"/>
+                <Option value="MM" name="line_width_unit" type="QString"/>
+                <Option value="0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="0" name="ring_filter" type="QString"/>
+                <Option value="0" name="trim_distance_end" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+                <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+                <Option value="0" name="trim_distance_start" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+                <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+                <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+                <Option value="0" name="use_custom_dash" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </layer>
-        <layer class="SimpleFill" locked="0" id="{7ea4045c-404f-4381-a72d-783993c70a74}" enabled="1" pass="0">
+        <layer pass="0" locked="0" id="{7ea4045c-404f-4381-a72d-783993c70a74}" class="SimpleFill" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="0,0,255,0" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="130,130,130,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.2" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="0,0,255,0,rgb:0,0,1,0" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="130,130,130,255,rgb:0.50980392156862742,0.50980392156862742,0.50980392156862742,1" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.2" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <source-symbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="0" frame_rate="10">
+      <symbol name="0" alpha="1" frame_rate="10" force_rhr="0" is_animated="0" type="fill" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{37755f80-d7d6-4b25-b532-e3cb11278484}" enabled="1" pass="0">
+        <layer pass="0" locked="0" id="{37755f80-d7d6-4b25-b532-e3cb11278484}" class="SimpleFill" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="237,76,44,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="0,0,0,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.26" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="237,76,44,255,rgb:0.92941176470588238,0.29803921568627451,0.17254901960784313,1" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,255,rgb:0,0,0,1" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.26" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -417,290 +417,282 @@
     </source-symbol>
     <rotation/>
     <sizescale/>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option value="" name="name" type="QString"/>
+        <Option name="properties"/>
+        <Option value="collection" name="type" type="QString"/>
+      </Option>
+    </data-defined-properties>
   </renderer-v2>
   <selection mode="Default">
     <selectionColor invalid="1"/>
     <selectionSymbol>
-      <symbol alpha="1" clip_to_extent="1" type="fill" is_animated="0" force_rhr="0" name="" frame_rate="10">
+      <symbol name="" alpha="1" frame_rate="10" force_rhr="0" is_animated="0" type="fill" clip_to_extent="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" id="{fdaa9ac4-2fcf-4ca3-b152-e5d8b4ca25e3}" enabled="1" pass="0">
+        <layer pass="0" locked="0" id="{fdaa9ac4-2fcf-4ca3-b152-e5d8b4ca25e3}" class="SimpleFill" enabled="1">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="0,0,255,255" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="35,35,35,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.26" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="0,0,255,255,rgb:0,0,1,1" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.26" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </selectionSymbol>
   </selection>
-  <customproperties>
-    <Option type="Map">
-      <Option type="List" name="dualview/previewExpressions">
-        <Option type="QString" value="&quot;commento&quot;"/>
-      </Option>
-      <Option type="int" value="0" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
-        <Option type="QString" value="pzp_layer"/>
-        <Option type="QString" value="pzp_process"/>
-      </Option>
-      <Option type="StringList" name="variableValues">
-        <Option type="QString" value="intensity"/>
-        <Option type="QString" value="3000"/>
-      </Option>
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <layerOpacity>0.7</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-    <DiagramCategory spacingUnit="MM" labelPlacementMethod="XHeight" penAlpha="255" backgroundAlpha="255" barWidth="5" direction="0" lineSizeScale="3x:0,0,0,0,0,0" penColor="#000000" scaleDependency="Area" rotationOffset="270" height="15" enabled="0" maxScaleDenominator="0" spacing="5" diagramOrientation="Up" backgroundColor="#ffffff" lineSizeType="MM" width="15" penWidth="0" spacingUnitScale="3x:0,0,0,0,0,0" opacity="1" showAxis="1" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" minimumSize="0" minScaleDenominator="0" scaleBasedVisibility="0">
-      <fontProperties italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+  <LinearlyInterpolatedDiagramRenderer classificationAttributeExpression="" lowerValue="0" attributeLegend="1" upperWidth="5" upperHeight="5" lowerHeight="0" lowerWidth="0" upperValue="0" diagramType="Histogram">
+    <DiagramCategory sizeScale="3x:0,0,0,0,0,0" penWidth="0" enabled="0" rotationOffset="270" diagramOrientation="Up" spacing="5" spacingUnitScale="3x:0,0,0,0,0,0" barWidth="5" lineSizeType="MM" direction="0" showAxis="1" backgroundColor="#ffffff" minimumSize="0" stackedDiagramSpacingUnit="MM" backgroundAlpha="255" lineSizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" width="15" stackedDiagramMode="Horizontal" minScaleDenominator="0" scaleBasedVisibility="0" sizeType="MM" penAlpha="255" stackedDiagramSpacingUnitScale="3x:0,0,0,0,0,0" penColor="#000000" labelPlacementMethod="XHeight" opacity="1" spacingUnit="MM" maxScaleDenominator="0" height="15" stackedDiagramSpacing="0">
+      <fontProperties description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
+      <attribute color="#000000" colorOpacity="1" label="" field=""/>
       <axisSymbol>
-        <symbol alpha="1" clip_to_extent="1" type="line" is_animated="0" force_rhr="0" name="" frame_rate="10">
+        <symbol name="" alpha="1" frame_rate="10" force_rhr="0" is_animated="0" type="line" clip_to_extent="1">
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
-          <layer class="SimpleLine" locked="0" id="{72f8cd2e-f523-4a94-83f0-43847254725d}" enabled="1" pass="0">
+          <layer pass="0" locked="0" id="{72f8cd2e-f523-4a94-83f0-43847254725d}" class="SimpleLine" enabled="1">
             <Option type="Map">
-              <Option type="QString" value="0" name="align_dash_pattern"/>
-              <Option type="QString" value="square" name="capstyle"/>
-              <Option type="QString" value="5;2" name="customdash"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-              <Option type="QString" value="MM" name="customdash_unit"/>
-              <Option type="QString" value="0" name="dash_pattern_offset"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-              <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-              <Option type="QString" value="0" name="draw_inside_polygon"/>
-              <Option type="QString" value="bevel" name="joinstyle"/>
-              <Option type="QString" value="35,35,35,255" name="line_color"/>
-              <Option type="QString" value="solid" name="line_style"/>
-              <Option type="QString" value="0.26" name="line_width"/>
-              <Option type="QString" value="MM" name="line_width_unit"/>
-              <Option type="QString" value="0" name="offset"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-              <Option type="QString" value="MM" name="offset_unit"/>
-              <Option type="QString" value="0" name="ring_filter"/>
-              <Option type="QString" value="0" name="trim_distance_end"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-              <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-              <Option type="QString" value="0" name="trim_distance_start"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-              <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-              <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-              <Option type="QString" value="0" name="use_custom_dash"/>
-              <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              <Option value="0" name="align_dash_pattern" type="QString"/>
+              <Option value="square" name="capstyle" type="QString"/>
+              <Option value="5;2" name="customdash" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+              <Option value="MM" name="customdash_unit" type="QString"/>
+              <Option value="0" name="dash_pattern_offset" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+              <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+              <Option value="0" name="draw_inside_polygon" type="QString"/>
+              <Option value="bevel" name="joinstyle" type="QString"/>
+              <Option value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="line_color" type="QString"/>
+              <Option value="solid" name="line_style" type="QString"/>
+              <Option value="0.26" name="line_width" type="QString"/>
+              <Option value="MM" name="line_width_unit" type="QString"/>
+              <Option value="0" name="offset" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="0" name="ring_filter" type="QString"/>
+              <Option value="0" name="trim_distance_end" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+              <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+              <Option value="0" name="trim_distance_start" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+              <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+              <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+              <Option value="0" name="use_custom_dash" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
             </Option>
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
           </layer>
         </symbol>
       </axisSymbol>
     </DiagramCategory>
-  </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings showAll="1" linePlacementFlags="18" placement="1" obstacle="0" dist="0" priority="0" zIndex="0">
+  </LinearlyInterpolatedDiagramRenderer>
+  <DiagramLayerSettings priority="0" zIndex="0" placement="1" showAll="1" linePlacementFlags="18" obstacle="0" dist="0">
     <properties>
       <Option type="Map">
-        <Option type="QString" value="" name="name"/>
+        <Option value="" name="name" type="QString"/>
         <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
+        <Option value="collection" name="type" type="QString"/>
       </Option>
     </properties>
   </DiagramLayerSettings>
   <geometryOptions removeDuplicateNodes="1" geometryPrecision="0.001">
     <activeChecks type="StringList">
-      <Option type="QString" value="QgsIsValidCheck"/>
+      <Option value="QgsIsValidCheck" type="QString"/>
     </activeChecks>
     <checkConfiguration type="Map">
-      <Option type="Map" name="QgsGeometryGapCheck">
-        <Option type="double" value="0" name="allowedGapsBuffer"/>
-        <Option type="bool" value="false" name="allowedGapsEnabled"/>
-        <Option type="QString" value="" name="allowedGapsLayer"/>
+      <Option name="QgsGeometryGapCheck" type="Map">
+        <Option value="0" name="allowedGapsBuffer" type="double"/>
+        <Option value="false" name="allowedGapsEnabled" type="bool"/>
+        <Option value="" name="allowedGapsLayer" type="QString"/>
       </Option>
     </checkConfiguration>
   </geometryOptions>
-  <legend type="default-vector" showLabelLegend="0"/>
+  <legend showLabelLegend="0" type="default-vector"/>
   <referencedLayers/>
   <fieldConfiguration>
-    <field configurationFlags="NoFlag" name="fid">
+    <field name="fid" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="prob_rottura">
+    <field name="prob_rottura" configurationFlags="NoFlag">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>"/>
+                <Option value="{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" name="&lt;NULL>" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1003" name="alta"/>
+                <Option value="1003" name="alta" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1001" name="bassa"/>
+                <Option value="1001" name="bassa" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1002" name="media"/>
+                <Option value="1002" name="media" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1000" name="molto bassa"/>
+                <Option value="1000" name="molto bassa" type="QString"/>
               </Option>
             </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="classe_intensita">
+    <field name="classe_intensita" configurationFlags="NoFlag">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="1002" name="Debole"/>
+                <Option value="1002" name="Debole" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1004" name="Forte"/>
+                <Option value="1004" name="Forte" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1001" name="Impatto presente"/>
+                <Option value="1001" name="Impatto presente" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1003" name="Medio"/>
+                <Option value="1003" name="Medio" type="QString"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1000" name="Nessun impatto"/>
+                <Option value="1000" name="Nessun impatto" type="QString"/>
               </Option>
             </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="fonte_proc">
+    <field name="fonte_proc" configurationFlags="NoFlag">
       <editWidget type="ValueRelation">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="AllowMulti"/>
-            <Option type="bool" value="false" name="AllowNull"/>
-            <Option type="QString" value="Case&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 0 then 'Sconosciuto'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1001 then 'Scenario puntuale'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1000 then 'Scenario diffuso'&#xd;&#xa;&#x9;else '_'&#xd;&#xa;End" name="Description"/>
-            <Option type="QString" value="" name="FilterExpression"/>
-            <Option type="QString" value="fonte_proc" name="Key"/>
-            <Option type="QString" value="Zona_sorgente__fonte_processo__5b9d7400_b480_4544_b701_66f3d70b7b75" name="Layer"/>
-            <Option type="QString" value="Zona sorgente (fonte processo)" name="LayerName"/>
-            <Option type="QString" value="ogr" name="LayerProviderName"/>
-            <Option type="QString" value="F:\UPIP\06_StrumentiGis\02_Progetti base\09_Plugin QGIS\01_Test QGIS\Test plugin vers. 1.4.4\data_3000_25032025_142655.gpkg|layername=Zona sorgente (fonte processo)" name="LayerSource"/>
-            <Option type="int" value="1" name="NofColumns"/>
-            <Option type="bool" value="false" name="OrderByValue"/>
-            <Option type="bool" value="false" name="UseCompleter"/>
-            <Option type="QString" value="fonte_proc" name="Value"/>
+            <Option value="false" name="AllowMulti" type="bool"/>
+            <Option value="false" name="AllowNull" type="bool"/>
+            <Option value="Case&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 0 then 'Sconosciuto'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1001 then 'Scenario puntuale'&#xd;&#xa;&#x9;when &quot;scenario&quot;  = 1000 then 'Scenario diffuso'&#xd;&#xa;&#x9;else '_'&#xd;&#xa;End" name="Description" type="QString"/>
+            <Option name="FilterExpression" type="invalid"/>
+            <Option value="fonte_proc" name="Key" type="QString"/>
+            <Option value="Zona_sorgente__fonte_processo__5b9d7400_b480_4544_b701_66f3d70b7b75" name="Layer" type="QString"/>
+            <Option value="Zona sorgente (fonte processo)" name="LayerName" type="QString"/>
+            <Option value="ogr" name="LayerProviderName" type="QString"/>
+            <Option value="F:\UPIP\06_StrumentiGis\02_Progetti base\09_Plugin QGIS\01_Test QGIS\Test plugin vers. 1.4.4\data_3000_25032025_142655.gpkg|layername=Zona sorgente (fonte processo)" name="LayerSource" type="QString"/>
+            <Option value="1" name="NofColumns" type="int"/>
+            <Option value="false" name="OrderByValue" type="bool"/>
+            <Option value="false" name="UseCompleter" type="bool"/>
+            <Option value="fonte_proc" name="Value" type="QString"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="proc_parz">
+    <field name="proc_parz" configurationFlags="NoFlag">
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="3000" name="Caduta sassi o blocchi"/>
+                <Option value="3000" name="Caduta sassi o blocchi" type="QString"/>
               </Option>
             </Option>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="commento">
+    <field name="commento" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="periodo_ritorno">
+    <field name="area" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="layer">
+    <field name="periodo_ritorno" configurationFlags="NoFlag">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="layer" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="NoFlag" name="path">
+    <field name="path" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
         <config>
           <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="NoFlag" name="area">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
-          </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" field="fid" name="Identificativo"/>
-    <alias index="1" field="prob_rottura" name="Probabilità di rottura"/>
-    <alias index="2" field="classe_intensita" name="Intensità (impatto)"/>
-    <alias index="3" field="fonte_proc" name="Fonte processo"/>
-    <alias index="4" field="proc_parz" name="Processo"/>
-    <alias index="5" field="commento" name="Commento"/>
-    <alias index="6" field="periodo_ritorno" name="Periodo di ritorno"/>
-    <alias index="7" field="layer" name=""/>
-    <alias index="8" field="path" name=""/>
-    <alias index="9" field="area" name="Area"/>
+    <alias name="Identificativo" index="0" field="fid"/>
+    <alias name="Probabilità di rottura" index="1" field="prob_rottura"/>
+    <alias name="Intensità (impatto)" index="2" field="classe_intensita"/>
+    <alias name="Fonte processo" index="3" field="fonte_proc"/>
+    <alias name="Processo" index="4" field="proc_parz"/>
+    <alias name="Commento" index="5" field="commento"/>
+    <alias name="Area" index="6" field="area"/>
+    <alias name="Periodo di ritorno" index="7" field="periodo_ritorno"/>
+    <alias name="" index="8" field="layer"/>
+    <alias name="" index="9" field="path"/>
   </aliases>
   <splitPolicies>
     <policy policy="Duplicate" field="fid"/>
@@ -709,66 +701,78 @@
     <policy policy="Duplicate" field="fonte_proc"/>
     <policy policy="Duplicate" field="proc_parz"/>
     <policy policy="Duplicate" field="commento"/>
+    <policy policy="Duplicate" field="area"/>
     <policy policy="Duplicate" field="periodo_ritorno"/>
     <policy policy="Duplicate" field="layer"/>
     <policy policy="Duplicate" field="path"/>
-    <policy policy="Duplicate" field="area"/>
   </splitPolicies>
+  <duplicatePolicies>
+    <policy policy="Duplicate" field="fid"/>
+    <policy policy="Duplicate" field="prob_rottura"/>
+    <policy policy="Duplicate" field="classe_intensita"/>
+    <policy policy="Duplicate" field="fonte_proc"/>
+    <policy policy="Duplicate" field="proc_parz"/>
+    <policy policy="Duplicate" field="commento"/>
+    <policy policy="Duplicate" field="area"/>
+    <policy policy="Duplicate" field="periodo_ritorno"/>
+    <policy policy="Duplicate" field="layer"/>
+    <policy policy="Duplicate" field="path"/>
+  </duplicatePolicies>
   <defaults>
-    <default field="fid" applyOnUpdate="0" expression=""/>
-    <default field="prob_rottura" applyOnUpdate="0" expression=""/>
-    <default field="classe_intensita" applyOnUpdate="0" expression=""/>
-    <default field="fonte_proc" applyOnUpdate="0" expression=""/>
-    <default field="proc_parz" applyOnUpdate="0" expression="@pzp_process"/>
-    <default field="commento" applyOnUpdate="0" expression=""/>
-    <default field="periodo_ritorno" applyOnUpdate="0" expression=""/>
-    <default field="layer" applyOnUpdate="0" expression=""/>
-    <default field="path" applyOnUpdate="0" expression=""/>
-    <default field="area" applyOnUpdate="0" expression=""/>
+    <default applyOnUpdate="0" expression="" field="fid"/>
+    <default applyOnUpdate="0" expression="" field="prob_rottura"/>
+    <default applyOnUpdate="0" expression="" field="classe_intensita"/>
+    <default applyOnUpdate="0" expression="" field="fonte_proc"/>
+    <default applyOnUpdate="0" expression="@pzp_process" field="proc_parz"/>
+    <default applyOnUpdate="0" expression="" field="commento"/>
+    <default applyOnUpdate="0" expression="" field="area"/>
+    <default applyOnUpdate="0" expression="" field="periodo_ritorno"/>
+    <default applyOnUpdate="0" expression="" field="layer"/>
+    <default applyOnUpdate="0" expression="" field="path"/>
   </defaults>
   <constraints>
-    <constraint constraints="3" unique_strength="1" field="fid" notnull_strength="1" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="prob_rottura" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" field="classe_intensita" notnull_strength="1" exp_strength="0"/>
-    <constraint constraints="1" unique_strength="0" field="fonte_proc" notnull_strength="1" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="proc_parz" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="commento" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="5" unique_strength="0" field="periodo_ritorno" notnull_strength="1" exp_strength="1"/>
-    <constraint constraints="0" unique_strength="0" field="layer" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="path" notnull_strength="0" exp_strength="0"/>
-    <constraint constraints="0" unique_strength="0" field="area" notnull_strength="0" exp_strength="0"/>
+    <constraint exp_strength="0" constraints="3" notnull_strength="1" unique_strength="1" field="fid"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" unique_strength="0" field="prob_rottura"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" unique_strength="0" field="classe_intensita"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" unique_strength="0" field="fonte_proc"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" unique_strength="0" field="proc_parz"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" unique_strength="0" field="commento"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" unique_strength="0" field="area"/>
+    <constraint exp_strength="1" constraints="5" notnull_strength="1" unique_strength="0" field="periodo_ritorno"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" unique_strength="0" field="layer"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" unique_strength="0" field="path"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="fid" exp="" desc=""/>
-    <constraint field="prob_rottura" exp="" desc=""/>
-    <constraint field="classe_intensita" exp="" desc=""/>
-    <constraint field="fonte_proc" exp="" desc=""/>
-    <constraint field="proc_parz" exp="" desc=""/>
-    <constraint field="commento" exp="" desc=""/>
-    <constraint field="periodo_ritorno" exp="&quot;periodo_ritorno&quot; > 0" desc=""/>
-    <constraint field="layer" exp="" desc=""/>
-    <constraint field="path" exp="" desc=""/>
-    <constraint field="area" exp="" desc=""/>
+    <constraint exp="" desc="" field="fid"/>
+    <constraint exp="" desc="" field="prob_rottura"/>
+    <constraint exp="" desc="" field="classe_intensita"/>
+    <constraint exp="" desc="" field="fonte_proc"/>
+    <constraint exp="" desc="" field="proc_parz"/>
+    <constraint exp="" desc="" field="commento"/>
+    <constraint exp="" desc="" field="area"/>
+    <constraint exp="&quot;periodo_ritorno&quot; > 0" desc="" field="periodo_ritorno"/>
+    <constraint exp="" desc="" field="layer"/>
+    <constraint exp="" desc="" field="path"/>
   </constraintExpressions>
   <expressionfields>
-    <field precision="0" length="0" subType="0" type="2" comment="" expression=" $area " name="area" typeName="integer"/>
+    <field precision="0" name="area" subType="0" expression=" $area " length="0" comment="" typeName="integer" type="2"/>
   </expressionfields>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
   </attributeactions>
-  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="&quot;fid&quot;" sortOrder="0">
+  <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="&quot;fid&quot;">
     <columns>
-      <column type="field" name="fid" width="-1" hidden="0"/>
-      <column type="field" name="prob_rottura" width="-1" hidden="0"/>
-      <column type="field" name="classe_intensita" width="-1" hidden="0"/>
-      <column type="field" name="fonte_proc" width="-1" hidden="0"/>
-      <column type="field" name="proc_parz" width="187" hidden="0"/>
-      <column type="field" name="commento" width="-1" hidden="0"/>
-      <column type="field" name="area" width="-1" hidden="0"/>
-      <column type="field" name="periodo_ritorno" width="-1" hidden="0"/>
-      <column type="field" name="layer" width="-1" hidden="0"/>
-      <column type="field" name="path" width="99" hidden="0"/>
-      <column type="actions" width="-1" hidden="1"/>
+      <column name="fid" hidden="0" width="-1" type="field"/>
+      <column name="prob_rottura" hidden="0" width="-1" type="field"/>
+      <column name="classe_intensita" hidden="0" width="-1" type="field"/>
+      <column name="fonte_proc" hidden="0" width="-1" type="field"/>
+      <column name="proc_parz" hidden="0" width="187" type="field"/>
+      <column name="commento" hidden="0" width="-1" type="field"/>
+      <column name="area" hidden="0" width="-1" type="field"/>
+      <column name="periodo_ritorno" hidden="0" width="-1" type="field"/>
+      <column name="layer" hidden="0" width="-1" type="field"/>
+      <column name="path" hidden="0" width="99" type="field"/>
+      <column hidden="1" width="-1" type="actions"/>
     </columns>
   </attributetableconfig>
   <conditionalstyles>
@@ -800,84 +804,84 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-      <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+    <labelStyle overrideLabelColor="0" labelColor="" overrideLabelFont="0">
+      <labelFont description="Ubuntu Sans,11,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
     </labelStyle>
-    <attributeEditorContainer collapsed="0" visibilityExpressionEnabled="0" showLabel="1" type="Tab" collapsedExpressionEnabled="0" verticalStretch="0" groupBox="0" collapsedExpression="" visibilityExpression="" name="Attributi" horizontalStretch="0" columnCount="1">
-      <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-        <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+    <attributeEditorContainer columnCount="1" visibilityExpressionEnabled="0" name="Attributi" visibilityExpression="" horizontalStretch="0" groupBox="0" showLabel="1" collapsedExpressionEnabled="0" collapsedExpression="" verticalStretch="0" type="Tab" collapsed="0">
+      <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+        <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
       </labelStyle>
-      <attributeEditorField showLabel="1" index="3" verticalStretch="0" name="fonte_proc" horizontalStretch="0">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorField name="fonte_proc" horizontalStretch="0" showLabel="1" index="3" verticalStretch="0">
+        <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+          <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField showLabel="1" index="2" verticalStretch="0" name="classe_intensita" horizontalStretch="0">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorField name="classe_intensita" horizontalStretch="0" showLabel="1" index="2" verticalStretch="0">
+        <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+          <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField showLabel="1" index="6" verticalStretch="0" name="periodo_ritorno" horizontalStretch="0">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorField name="periodo_ritorno" horizontalStretch="0" showLabel="1" index="7" verticalStretch="0">
+        <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+          <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField showLabel="1" index="5" verticalStretch="0" name="commento" horizontalStretch="0">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorField name="commento" horizontalStretch="0" showLabel="1" index="5" verticalStretch="0">
+        <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+          <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorContainer collapsed="0" visibilityExpressionEnabled="0" showLabel="1" type="GroupBox" collapsedExpressionEnabled="0" verticalStretch="0" groupBox="1" collapsedExpression="" visibilityExpression="" name="Sistema (automatico)" horizontalStretch="0" columnCount="1">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorContainer columnCount="1" visibilityExpressionEnabled="0" name="Sistema (automatico)" visibilityExpression="" horizontalStretch="0" groupBox="1" showLabel="1" collapsedExpressionEnabled="0" collapsedExpression="" verticalStretch="0" type="GroupBox" collapsed="0">
+        <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+          <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
         </labelStyle>
-        <attributeEditorField showLabel="1" index="4" verticalStretch="0" name="proc_parz" horizontalStretch="0">
-          <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-            <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+        <attributeEditorField name="proc_parz" horizontalStretch="0" showLabel="1" index="4" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField showLabel="1" index="0" verticalStretch="0" name="fid" horizontalStretch="0">
-          <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-            <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+        <attributeEditorField name="fid" horizontalStretch="0" showLabel="1" index="0" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
-        <attributeEditorField showLabel="1" index="9" verticalStretch="0" name="area" horizontalStretch="0">
-          <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-            <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+        <attributeEditorField name="area" horizontalStretch="0" showLabel="1" index="6" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
       </attributeEditorContainer>
-      <attributeEditorContainer collapsed="0" visibilityExpressionEnabled="0" showLabel="1" type="GroupBox" collapsedExpressionEnabled="0" verticalStretch="0" groupBox="1" collapsedExpression="" visibilityExpression="" name="Storico" horizontalStretch="0" columnCount="1">
-        <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-          <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+      <attributeEditorContainer columnCount="1" visibilityExpressionEnabled="0" name="Storico" visibilityExpression="" horizontalStretch="0" groupBox="1" showLabel="1" collapsedExpressionEnabled="0" collapsedExpression="" verticalStretch="0" type="GroupBox" collapsed="0">
+        <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+          <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
         </labelStyle>
-        <attributeEditorField showLabel="1" index="1" verticalStretch="0" name="prob_rottura" horizontalStretch="0">
-          <labelStyle overrideLabelFont="0" labelColor="0,0,0,255" overrideLabelColor="0">
-            <labelFont italic="0" strikethrough="0" bold="0" underline="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style=""/>
+        <attributeEditorField name="prob_rottura" horizontalStretch="0" showLabel="1" index="1" verticalStretch="0">
+          <labelStyle overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0">
+            <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" strikethrough="0" style="" underline="0" italic="0" bold="0"/>
           </labelStyle>
         </attributeEditorField>
       </attributeEditorContainer>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="0" name="area"/>
-    <field editable="0" name="area in m2"/>
-    <field editable="1" name="classe_intensita"/>
-    <field editable="1" name="commento"/>
-    <field editable="1" name="fid"/>
-    <field editable="1" name="fonte"/>
-    <field editable="1" name="fonte_proc"/>
-    <field editable="1" name="layer"/>
-    <field editable="1" name="liv_dettaglio"/>
-    <field editable="1" name="matrice"/>
-    <field editable="1" name="path"/>
-    <field editable="1" name="periodo_ritorno"/>
-    <field editable="1" name="prob_accadimento"/>
-    <field editable="1" name="prob_propagazione"/>
-    <field editable="1" name="prob_rottura"/>
-    <field editable="0" name="proc_parz"/>
-    <field editable="1" name="proc_parz_ch"/>
-    <field editable="1" name="scala"/>
+    <field name="area" editable="0"/>
+    <field name="area in m2" editable="0"/>
+    <field name="classe_intensita" editable="1"/>
+    <field name="commento" editable="1"/>
+    <field name="fid" editable="1"/>
+    <field name="fonte" editable="1"/>
+    <field name="fonte_proc" editable="1"/>
+    <field name="layer" editable="1"/>
+    <field name="liv_dettaglio" editable="1"/>
+    <field name="matrice" editable="1"/>
+    <field name="path" editable="1"/>
+    <field name="periodo_ritorno" editable="1"/>
+    <field name="prob_accadimento" editable="1"/>
+    <field name="prob_propagazione" editable="1"/>
+    <field name="prob_rottura" editable="1"/>
+    <field name="proc_parz" editable="0"/>
+    <field name="proc_parz_ch" editable="1"/>
+    <field name="scala" editable="1"/>
   </editable>
   <labelOnTop>
     <field name="area" labelOnTop="0"/>
@@ -900,17 +904,17 @@ def my_form_open(dialog, layer, feature):
     <field name="scala" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
-    <field reuseLastValue="0" name="area"/>
-    <field reuseLastValue="0" name="area in m2"/>
-    <field reuseLastValue="0" name="classe_intensita"/>
-    <field reuseLastValue="0" name="commento"/>
-    <field reuseLastValue="0" name="fid"/>
-    <field reuseLastValue="0" name="fonte_proc"/>
-    <field reuseLastValue="0" name="layer"/>
-    <field reuseLastValue="0" name="path"/>
-    <field reuseLastValue="0" name="periodo_ritorno"/>
-    <field reuseLastValue="0" name="prob_rottura"/>
-    <field reuseLastValue="0" name="proc_parz"/>
+    <field name="area" reuseLastValue="0"/>
+    <field name="area in m2" reuseLastValue="0"/>
+    <field name="classe_intensita" reuseLastValue="0"/>
+    <field name="commento" reuseLastValue="0"/>
+    <field name="fid" reuseLastValue="0"/>
+    <field name="fonte_proc" reuseLastValue="0"/>
+    <field name="layer" reuseLastValue="0"/>
+    <field name="path" reuseLastValue="0"/>
+    <field name="periodo_ritorno" reuseLastValue="0"/>
+    <field name="prob_rottura" reuseLastValue="0"/>
+    <field name="proc_parz" reuseLastValue="0"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>


### PR DESCRIPTION
That is, check if intensity layers are already present, and if so, archive them, moving them (along with its filtered ones) to an Archive group (change main intensity layer's `pzp_layer` variable, add timestamps to all new main intensity layers).

This is how it looks like right after running `Calcola propagazione` for a third time:

![image](https://github.com/user-attachments/assets/7f4e5727-425d-4e5e-8258-5c6bfe4816de)

And this is how the `Intensità completa - Archivio` group looks like when expanded:

![image](https://github.com/user-attachments/assets/7cd85de0-ea30-45b3-ba89-6f9953996694)


Fix #43 