### PR TITLE
Calcola propagazione: help the single-sided buffer to find polygons

### DIFF
--- a/pzp/calculation.py
+++ b/pzp/calculation.py
@@ -122,48 +122,61 @@ class PropagationTool:
         print(f"{layer_propagation=}")
         print(f"{layer_breaking=}")
 
-        result_01 = processing.run(
-            "pzp_utils:propagation",
-            {
-                "BREAKING_LAYER": layer_breaking.id(),
-                "BREAKING_FIELD": "prob_rottura",
-                "SOURCE_FIELD": "fonte_proc",
-                "PROPAGATION_LAYER": layer_propagation.id(),
-                "PROPAGATION_FIELD": "prob_propagazione",
-                "BREAKING_FIELD_PROP": "prob_rottura",
-                "SOURCE_FIELD_PROP": "fonte_proc",
-                "OUTPUT": "TEMPORARY_OUTPUT",
-            },
-        )
-        result_02 = processing.run(
-            "native:extractbyexpression",
-            {
-                "INPUT": result_01["OUTPUT"],
-                "EXPRESSION": f'"proc_parz" = {process_type}',
-                "OUTPUT": "TEMPORARY_OUTPUT",
-            },
-        )
+        try:
+            result_01 = processing.run(
+                "pzp_utils:propagation",
+                {
+                    "BREAKING_LAYER": layer_breaking.id(),
+                    "BREAKING_FIELD": "prob_rottura",
+                    "SOURCE_FIELD": "fonte_proc",
+                    "PROPAGATION_LAYER": layer_propagation.id(),
+                    "PROPAGATION_FIELD": "prob_propagazione",
+                    "BREAKING_FIELD_PROP": "prob_rottura",
+                    "SOURCE_FIELD_PROP": "fonte_proc",
+                    "OUTPUT": "TEMPORARY_OUTPUT",
+                },
+            )
+        except (QgsProcessingException, Exception) as e:
+            raise QgsProcessingException("The algorithm pzp_utils:propagation failed! " + str(e))
+
+        try:
+            result_02 = processing.run(
+                "native:extractbyexpression",
+                {
+                    "INPUT": result_01["OUTPUT"],
+                    "EXPRESSION": f'"proc_parz" = {process_type}',
+                    "OUTPUT": "TEMPORARY_OUTPUT",
+                },
+            )
+        except (QgsProcessingException, Exception) as e:
+            raise QgsProcessingException("The algorithm native:extractbyexpression failed! " + str(e))
 
         # Clippa per periodo di ritorno
-        result_03 = processing.run(
-            "pzp_utils:remove_overlappings",
-            {
-                "INPUT": result_02["OUTPUT"],
-                "INTENSITY_FIELD": "classe_intensita",
-                "PERIOD_FIELD": "periodo_ritorno",
-                "SOURCE_FIELD": "fonte_proc",
-                "OUTPUT": "TEMPORARY_OUTPUT",
-            },
-        )
+        try:
+            result_03 = processing.run(
+                "pzp_utils:remove_overlappings",
+                {
+                    "INPUT": result_02["OUTPUT"],
+                    "INTENSITY_FIELD": "classe_intensita",
+                    "PERIOD_FIELD": "periodo_ritorno",
+                    "SOURCE_FIELD": "fonte_proc",
+                    "OUTPUT": "TEMPORARY_OUTPUT",
+                },
+            )
+        except (QgsProcessingException, Exception) as e:
+            raise QgsProcessingException("The algorithm pzp_utils:remove_overlappings failed! " + str(e))
 
-        result = processing.run(
-            "native:deletecolumn",
-            {
-                "INPUT": result_03["OUTPUT"],
-                "COLUMN": ["fid"],
-                "OUTPUT": "TEMPORARY_OUTPUT",
-            },
-        )
+        try:
+            result = processing.run(
+                "native:deletecolumn",
+                {
+                    "INPUT": result_03["OUTPUT"],
+                    "COLUMN": ["fid"],
+                    "OUTPUT": "TEMPORARY_OUTPUT",
+                },
+            )
+        except (QgsProcessingException, Exception) as e:
+            raise QgsProcessingException("The algorithm native:deletecolumn failed! " + str(e))
 
         return result["OUTPUT"]
 

--- a/pzp/processing/propagation.py
+++ b/pzp/processing/propagation.py
@@ -3,6 +3,7 @@ from qgis.core import (
     Qgis,
     QgsFeature,
     QgsField,
+    QgsGeometry,
     QgsProcessing,
     QgsProcessingAlgorithm,
     QgsProcessingParameterFeatureSink,
@@ -238,6 +239,13 @@ class Propagation(QgsProcessingAlgorithm):
         return {self.OUTPUT: dest_id}
 
     def left_of_line(self, poly, line):
+        # Extend the line at the beginning and at the end,
+        # so that the single-sided buffer is wider, making
+        # it more probable to find corresponding polygons
+        const_line = line.geometry().constGet()
+        cloned_line = QgsGeometry(const_line.clone())
+        extended_line = cloned_line.extendLine(100, 100)
+
         # Expand the line on the left side and check if a point in the polygon is inside the buffer
-        buf = line.geometry().singleSidedBuffer(1000000, 4, Qgis.BufferSide.Left)
+        buf = extended_line.singleSidedBuffer(1000000, 4, Qgis.BufferSide.Left)
         return buf.contains(poly.geometry().pointOnSurface())


### PR DESCRIPTION
Fix #38 by extending the propagation line at both ends, making it more probable that the single-sided buffer can find the corresponding polygons.

Current situation with the first sample project in the aforementioned description:

![Screenshot from 2025-05-14 19-31-58](https://github.com/user-attachments/assets/e258120b-4ac1-4d4e-9d63-ef35b9f78d77)

Zoomed in (this is why it cannot find the correct polygon):
![Screenshot from 2025-05-14 19-32-47](https://github.com/user-attachments/assets/a6e1eb06-9ce5-4be0-be0d-bbf5077b5ec7)

New situation (after this PR):

![Screenshot from 2025-05-15 13-29-30](https://github.com/user-attachments/assets/ee62d087-53aa-4d66-bbf3-f134c3c068cb)


