### PR TITLE
Area layer should not have reference to process unless in caduta sassi

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ docker run --rm -e PYTHONPATH=/usr/share/qgis/python/plugins -v $PWD:/usr/src -w
 
 ### Layer Style definitions (.QML)
 
-When exporting .QML files for integration in the plugin select this categories:
+When exporting .QML files for integration in the plugin select these categories:
 
 - LayerConfiguration
 - Symbology

--- a/README.md
+++ b/README.md
@@ -8,10 +8,22 @@ Processing provider plugin.
 
 The user manual (ita) is published here: https://opengisch.github.io/pzp/
 
-## Run tests
+## Development
+
+### Run tests
 
 To run unit tests locally, first install Docker and then run this docker command from the PZP repo's root folder:
 
 ```bash
 docker run --rm -e PYTHONPATH=/usr/share/qgis/python/plugins -v $PWD:/usr/src -w /usr/src qgis/qgis:latest sh -c 'xvfb-run pytest'
 ```
+
+### Layer Style definitions (.QML)
+
+When exporting .QML files for integration in the plugin select this categories:
+
+- LayerConfiguration
+- Symbology
+- Labeling
+- Fields
+- Forms

--- a/pzp/add_process.py
+++ b/pzp/add_process.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from qgis.core import QgsExpressionContextUtils, QgsProject
 from qgis.PyQt.QtCore import QVariant
-from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QFileDialog, QMessageBox
+from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QMessageBox
 
 from pzp.processing import domains
 from pzp.utils import utils
@@ -21,20 +21,12 @@ class AddProcessDialog(QDialog, FORM_CLASS):
         for process in domains.PROCESS_TYPES.items():
             self.process_cbox.addItem(process[1], process[0])
 
-        self.directory_toolButton.clicked.connect(self.select_directory_clicked)
-
-    def select_directory_clicked(self):
-        directory = QFileDialog.getExistingDirectory(self, "Seleziona cartella")
-
-        if directory:
-            self.directory_lineEdit.setText(directory)
-
     def button_box_clicked(self, button):
         if self.buttonBox.buttonRole(button) == QDialogButtonBox.RejectRole:
             self.close()
             return
 
-        selected_directory = self.directory_lineEdit.text()
+        selected_directory = self.file_widget.filePath()
 
         # check if selected dir exists
         if not selected_directory or not os.path.exists(selected_directory):
@@ -54,9 +46,6 @@ class AddProcessDialog(QDialog, FORM_CLASS):
                 "Errore",
                 f"Si è verificato un errore durante l'aggiunta del processo: {exception}",
             )
-            return
-
-        if self.buttonBox.buttonRole(button) == QDialogButtonBox.ApplyRole:
             return
 
         self.close()
@@ -166,7 +155,7 @@ class AddProcessDialog(QDialog, FORM_CLASS):
         group_intensity_filtered = utils.create_group("Intensità (con filtri x visualizzazione scenari)", group)
         group_intensity_filtered.setExpanded(True)
 
-        if process_type in [2001, 2002, 3000, 4100, 4200]:
+        if process_type in [2001, 2002, 4100, 4200]:
             filter_params = [
                 ("\"periodo_ritorno\"='30'", "T 30"),
                 ("\"periodo_ritorno\"='100'", "T 100"),

--- a/pzp/add_process.py
+++ b/pzp/add_process.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from qgis.core import QgsExpressionContextUtils, QgsProject
 from qgis.PyQt.QtCore import QVariant
-from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QMessageBox
+from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QFileDialog, QMessageBox
 
 from pzp.processing import domains
 from pzp.utils import utils
@@ -21,15 +21,23 @@ class AddProcessDialog(QDialog, FORM_CLASS):
         for process in domains.PROCESS_TYPES.items():
             self.process_cbox.addItem(process[1], process[0])
 
-        self.file_widget.setFilter("*.gpkg;;*.GPKG")
+        self.directory_toolButton.clicked.connect(self.select_directory_clicked)
+
+    def select_directory_clicked(self):
+        directory = QFileDialog.getExistingDirectory(self, "Seleziona cartella")
+
+        if directory:
+            self.directory_lineEdit.setText(directory)
 
     def button_box_clicked(self, button):
         if self.buttonBox.buttonRole(button) == QDialogButtonBox.RejectRole:
             self.close()
             return
 
+        selected_directory = self.directory_lineEdit.text()
+
         # check if selected dir exists
-        if not self.file_widget.filePath() or not os.path.exists(self.file_widget.filePath()):
+        if not selected_directory or not os.path.exists(selected_directory):
             QMessageBox.critical(
                 self,
                 "Errore",
@@ -39,7 +47,7 @@ class AddProcessDialog(QDialog, FORM_CLASS):
 
         process_type = self.process_cbox.currentData()
         try:
-            self.add_process(process_type, self.file_widget.filePath())
+            self.add_process(process_type, selected_directory)
         except Exception as exception:
             QMessageBox.critical(
                 self,

--- a/pzp/qml/area.qml
+++ b/pzp/qml/area.qml
@@ -1,152 +1,14 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis labelsEnabled="1" version="3.42.2-Münster" simplifyDrawingTol="1" minScale="0" maxScale="0" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="1" readOnly="0" simplifyMaxScale="1" symbologyReferenceScale="-1" autoRefreshMode="Disabled" autoRefreshTime="0" simplifyAlgorithm="0" simplifyLocal="1">
+<qgis styleCategories="LayerConfiguration|Symbology|Labeling|Fields|Forms" version="3.40.3-Bratislava" readOnly="0" labelsEnabled="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <temporal durationUnit="min" accumulate="0" mode="0" startExpression="" limitMode="0" startField="" endField="" enabled="0" durationField="fid" endExpression="" fixedDuration="0">
-    <fixedRange>
-      <start></start>
-      <end></end>
-    </fixedRange>
-  </temporal>
-  <elevation symbology="Line" customToleranceEnabled="1" extrusion="0" type="IndividualFeatures" extrusionEnabled="0" clamping="Terrain" zoffset="0" zscale="1" binding="Centroid" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0">
-    <data-defined-properties>
-      <Option type="Map">
-        <Option name="name" type="QString" value=""/>
-        <Option name="properties"/>
-        <Option name="type" type="QString" value="collection"/>
-      </Option>
-    </data-defined-properties>
-    <profileLineSymbol>
-      <symbol name="" frame_rate="10" type="line" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
-        <data_defined_properties>
-          <Option type="Map">
-            <Option name="name" type="QString" value=""/>
-            <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
-          </Option>
-        </data_defined_properties>
-        <layer id="{397d7a2f-44c2-4134-8353-1d4111d56c85}" class="SimpleLine" locked="0" enabled="1" pass="0">
-          <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0"/>
-            <Option name="capstyle" type="QString" value="square"/>
-            <Option name="customdash" type="QString" value="5;2"/>
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="customdash_unit" type="QString" value="MM"/>
-            <Option name="dash_pattern_offset" type="QString" value="0"/>
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-            <Option name="draw_inside_polygon" type="QString" value="0"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="line_color" type="QString" value="190,178,151,255,rgb:0.74509803921568629,0.69803921568627447,0.59215686274509804,1"/>
-            <Option name="line_style" type="QString" value="solid"/>
-            <Option name="line_width" type="QString" value="0.6"/>
-            <Option name="line_width_unit" type="QString" value="MM"/>
-            <Option name="offset" type="QString" value="0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="ring_filter" type="QString" value="0"/>
-            <Option name="trim_distance_end" type="QString" value="0"/>
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-            <Option name="trim_distance_start" type="QString" value="0"/>
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-            <Option name="use_custom_dash" type="QString" value="0"/>
-            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-          </Option>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" type="QString" value=""/>
-              <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-      </symbol>
-    </profileLineSymbol>
-    <profileFillSymbol>
-      <symbol name="" frame_rate="10" type="fill" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
-        <data_defined_properties>
-          <Option type="Map">
-            <Option name="name" type="QString" value=""/>
-            <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
-          </Option>
-        </data_defined_properties>
-        <layer id="{a52e8d0e-d914-49af-b8f6-b467fa93f585}" class="SimpleFill" locked="0" enabled="1" pass="0">
-          <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="color" type="QString" value="190,178,151,255,rgb:0.74509803921568629,0.69803921568627447,0.59215686274509804,1"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="136,127,108,255,rgb:0.53220416571297779,0.49858854047455559,0.42296482795452811,1"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0.2"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="style" type="QString" value="solid"/>
-          </Option>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" type="QString" value=""/>
-              <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-      </symbol>
-    </profileFillSymbol>
-    <profileMarkerSymbol>
-      <symbol name="" frame_rate="10" type="marker" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
-        <data_defined_properties>
-          <Option type="Map">
-            <Option name="name" type="QString" value=""/>
-            <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
-          </Option>
-        </data_defined_properties>
-        <layer id="{43d11b82-cdd8-4194-8362-f44bc9c8b460}" class="SimpleMarker" locked="0" enabled="1" pass="0">
-          <Option type="Map">
-            <Option name="angle" type="QString" value="0"/>
-            <Option name="cap_style" type="QString" value="square"/>
-            <Option name="color" type="QString" value="190,178,151,255,rgb:0.74509803921568629,0.69803921568627447,0.59215686274509804,1"/>
-            <Option name="horizontal_anchor_point" type="QString" value="1"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="name" type="QString" value="diamond"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="136,127,108,255,rgb:0.53220416571297779,0.49858854047455559,0.42296482795452811,1"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0.2"/>
-            <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="scale_method" type="QString" value="diameter"/>
-            <Option name="size" type="QString" value="3"/>
-            <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="size_unit" type="QString" value="MM"/>
-            <Option name="vertical_anchor_point" type="QString" value="1"/>
-          </Option>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" type="QString" value=""/>
-              <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
-            </Option>
-          </data_defined_properties>
-        </layer>
-      </symbol>
-    </profileMarkerSymbol>
-  </elevation>
-  <renderer-v2 symbollevels="0" enableorderby="0" type="singleSymbol" referencescale="-1" forceraster="0">
+  <renderer-v2 symbollevels="0" type="singleSymbol" forceraster="0" referencescale="-1" enableorderby="0">
     <symbols>
-      <symbol name="0" frame_rate="10" type="fill" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
+      <symbol name="0" frame_rate="10" type="fill" force_rhr="0" clip_to_extent="1" alpha="1" is_animated="0">
         <data_defined_properties>
           <Option type="Map">
             <Option name="name" type="QString" value=""/>
@@ -154,7 +16,7 @@
             <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer id="{e2908301-c6cc-40b6-86af-baf59f9dbd5e}" class="SimpleFill" locked="0" enabled="1" pass="0">
+        <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{e2908301-c6cc-40b6-86af-baf59f9dbd5e}">
           <Option type="Map">
             <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
             <Option name="color" type="QString" value="0,0,255,0,rgb:0,0,1,0"/>
@@ -176,7 +38,7 @@
             </Option>
           </data_defined_properties>
         </layer>
-        <layer id="{fa66d403-2161-4206-abd4-5fa7fab3fc2c}" class="LinePatternFill" locked="0" enabled="1" pass="0">
+        <layer pass="0" class="LinePatternFill" enabled="1" locked="0" id="{fa66d403-2161-4206-abd4-5fa7fab3fc2c}">
           <Option type="Map">
             <Option name="angle" type="QString" value="45"/>
             <Option name="clip_mode" type="QString" value="during_render"/>
@@ -201,7 +63,7 @@
               <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
-          <symbol name="@0@1" frame_rate="10" type="line" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
+          <symbol name="@0@1" frame_rate="10" type="line" force_rhr="0" clip_to_extent="1" alpha="1" is_animated="0">
             <data_defined_properties>
               <Option type="Map">
                 <Option name="name" type="QString" value=""/>
@@ -209,7 +71,7 @@
                 <Option name="type" type="QString" value="collection"/>
               </Option>
             </data_defined_properties>
-            <layer id="{d5875839-1bb3-4e74-8b0b-85cca81b4357}" class="SimpleLine" locked="0" enabled="1" pass="0">
+            <layer pass="0" class="SimpleLine" enabled="1" locked="0" id="{d5875839-1bb3-4e74-8b0b-85cca81b4357}">
               <Option type="Map">
                 <Option name="align_dash_pattern" type="QString" value="0"/>
                 <Option name="capstyle" type="QString" value="square"/>
@@ -264,7 +126,7 @@
   <selection mode="Default">
     <selectionColor invalid="1"/>
     <selectionSymbol>
-      <symbol name="" frame_rate="10" type="fill" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
+      <symbol name="" frame_rate="10" type="fill" force_rhr="0" clip_to_extent="1" alpha="1" is_animated="0">
         <data_defined_properties>
           <Option type="Map">
             <Option name="name" type="QString" value=""/>
@@ -272,7 +134,7 @@
             <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer id="{6b17d3ff-6506-4e7d-b467-92ae3d6174ac}" class="SimpleFill" locked="0" enabled="1" pass="0">
+        <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="{6b17d3ff-6506-4e7d-b467-92ae3d6174ac}">
           <Option type="Map">
             <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
             <Option name="color" type="QString" value="0,0,255,255,rgb:0,0,1,1"/>
@@ -299,12 +161,12 @@
   </selection>
   <labeling type="simple">
     <settings calloutType="simple">
-      <text-style fontFamily="Open Sans" textOrientation="horizontal" multilineHeightUnit="Percentage" tabStopDistance="80" namedStyle="Regular" fontWeight="50" fontUnderline="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontWordSpacing="0" fontStrikeout="0" fontLetterSpacing="0" multilineHeight="1" fontItalic="0" fontKerning="1" allowHtml="0" textOpacity="1" fontSizeUnit="Point" isExpression="0" capitalization="0" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" useSubstitutions="0" fieldName="commento" textColor="50,50,50,255,rgb:0.19607843137254902,0.19607843137254902,0.19607843137254902,1" fontSize="10" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" legendString="Aa" forcedBold="0" forcedItalic="0" blendMode="0">
+      <text-style fontWordSpacing="0" textOpacity="1" useSubstitutions="0" fontWeight="50" legendString="Aa" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" fontUnderline="0" tabStopDistanceUnit="Point" namedStyle="Regular" fontItalic="0" fieldName="commento" isExpression="0" forcedItalic="0" multilineHeightUnit="Percentage" allowHtml="0" textColor="50,50,50,255,rgb:0.19607843137254902,0.19607843137254902,0.19607843137254902,1" tabStopDistance="80" multilineHeight="1" fontKerning="1" textOrientation="horizontal" fontSize="10" fontStrikeout="0" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" fontLetterSpacing="0" blendMode="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontSizeUnit="Point" fontFamily="Open Sans" capitalization="0" forcedBold="0">
         <families/>
-        <text-buffer bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="250,250,250,255,rgb:0.98039215686274506,0.98039215686274506,0.98039215686274506,1" bufferOpacity="1" bufferJoinStyle="128" bufferSize="1" bufferDraw="0" bufferNoFill="1" bufferBlendMode="0"/>
-        <text-mask maskType="0" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1"/>
-        <background shapeSizeY="0" shapeBlendMode="0" shapeRadiiY="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSizeUnit="Point" shapeOffsetX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotation="0" shapeDraw="0" shapeSizeType="0" shapeBorderWidth="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="Point" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="Point" shapeRotationType="0" shapeType="0" shapeOpacity="1" shapeOffsetUnit="Point" shapeSizeX="0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeOffsetY="0" shapeJoinStyle="64" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0">
-          <symbol name="markerSymbol" frame_rate="10" type="marker" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
+        <text-buffer bufferBlendMode="0" bufferOpacity="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="250,250,250,255,rgb:0.98039215686274506,0.98039215686274506,0.98039215686274506,1" bufferJoinStyle="128" bufferSizeUnits="MM" bufferNoFill="1" bufferDraw="0" bufferSize="1"/>
+        <text-mask maskSize2="1.5" maskSizeUnits="MM" maskEnabled="0" maskedSymbolLayers="" maskJoinStyle="128" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1" maskType="0"/>
+        <background shapeRadiiUnit="Point" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeRotation="0" shapeType="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeSizeX="0" shapeBorderWidth="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="Point" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeSVGFile="" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeOffsetX="0" shapeDraw="0" shapeRadiiY="0" shapeOpacity="1" shapeRotationType="0" shapeSizeType="0" shapeOffsetUnit="Point" shapeJoinStyle="64" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeSizeY="0" shapeOffsetY="0" shapeRadiiX="0" shapeBorderWidthUnit="Point">
+          <symbol name="markerSymbol" frame_rate="10" type="marker" force_rhr="0" clip_to_extent="1" alpha="1" is_animated="0">
             <data_defined_properties>
               <Option type="Map">
                 <Option name="name" type="QString" value=""/>
@@ -312,7 +174,7 @@
                 <Option name="type" type="QString" value="collection"/>
               </Option>
             </data_defined_properties>
-            <layer id="" class="SimpleMarker" locked="0" enabled="1" pass="0">
+            <layer pass="0" class="SimpleMarker" enabled="1" locked="0" id="">
               <Option type="Map">
                 <Option name="angle" type="QString" value="0"/>
                 <Option name="cap_style" type="QString" value="square"/>
@@ -343,7 +205,7 @@
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol name="fillSymbol" frame_rate="10" type="fill" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
+          <symbol name="fillSymbol" frame_rate="10" type="fill" force_rhr="0" clip_to_extent="1" alpha="1" is_animated="0">
             <data_defined_properties>
               <Option type="Map">
                 <Option name="name" type="QString" value=""/>
@@ -351,7 +213,7 @@
                 <Option name="type" type="QString" value="collection"/>
               </Option>
             </data_defined_properties>
-            <layer id="" class="SimpleFill" locked="0" enabled="1" pass="0">
+            <layer pass="0" class="SimpleFill" enabled="1" locked="0" id="">
               <Option type="Map">
                 <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
                 <Option name="color" type="QString" value="255,255,255,255,rgb:1,1,1,1"/>
@@ -375,7 +237,7 @@
             </layer>
           </symbol>
         </background>
-        <shadow shadowOffsetAngle="135" shadowRadius="1.5" shadowUnder="0" shadowBlendMode="6" shadowRadiusUnit="MM" shadowRadiusAlphaOnly="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowDraw="0" shadowOffsetUnit="MM" shadowOffsetDist="1" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
+        <shadow shadowOffsetAngle="135" shadowOffsetUnit="MM" shadowOpacity="0.69999999999999996" shadowOffsetDist="1" shadowDraw="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowBlendMode="6" shadowUnder="0" shadowOffsetGlobal="1" shadowRadius="1.5" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowScale="100" shadowRadiusAlphaOnly="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0"/>
         <dd_properties>
           <Option type="Map">
             <Option name="name" type="QString" value=""/>
@@ -385,9 +247,9 @@
         </dd_properties>
         <substitutions/>
       </text-style>
-      <text-format addDirectionSymbol="0" placeDirectionSymbol="0" rightDirectionSymbol=">" multilineAlign="3" formatNumbers="0" plussign="0" leftDirectionSymbol="&lt;" useMaxLineLengthForAutoWrap="1" decimals="3" reverseDirectionSymbol="0" wrapChar="" autoWrapLength="0"/>
-      <placement placement="0" repeatDistanceUnits="MM" yOffset="0" maximumDistance="0" distMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" lineAnchorTextPoint="FollowPlacement" distUnits="MM" maxCurvedCharAngleIn="25" preserveRotation="1" maximumDistanceUnit="MM" offsetType="0" overrunDistance="0" xOffset="0" rotationUnit="AngleDegrees" quadOffset="4" offsetUnits="MM" placementFlags="10" geometryGeneratorType="PointGeometry" centroidWhole="0" geometryGenerator="" centroidInside="0" lineAnchorClipping="0" geometryGeneratorEnabled="0" overlapHandling="PreventOverlap" lineAnchorType="0" lineAnchorPercent="0.5" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="0" prioritization="PreferCloser" overrunDistanceUnit="MM" layerType="PolygonGeometry" polygonPlacementFlags="2" rotationAngle="0" maxCurvedCharAngleOut="-25" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" dist="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" priority="5"/>
-      <rendering upsidedownLabels="0" drawLabels="1" unplacedVisibility="0" labelPerPart="0" scaleVisibility="0" obstacleType="1" mergeLines="0" limitNumLabels="0" fontMinPixelSize="3" fontMaxPixelSize="10000" obstacle="1" fontLimitPixelSize="0" zIndex="0" scaleMax="0" minFeatureSize="0" maxNumLabels="2000" obstacleFactor="1" scaleMin="0"/>
+      <text-format decimals="3" placeDirectionSymbol="0" wrapChar="" multilineAlign="3" reverseDirectionSymbol="0" plussign="0" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" leftDirectionSymbol="&lt;" addDirectionSymbol="0" rightDirectionSymbol=">" formatNumbers="0"/>
+      <placement distMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="0" centroidInside="0" placement="0" maximumDistanceUnit="MM" layerType="PolygonGeometry" polygonPlacementFlags="2" geometryGeneratorType="PointGeometry" distUnits="MM" repeatDistance="0" rotationUnit="AngleDegrees" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" lineAnchorPercent="0.5" centroidWhole="0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" placementFlags="10" geometryGenerator="" overrunDistanceUnit="MM" maximumDistance="0" rotationAngle="0" xOffset="0" priority="5" maxCurvedCharAngleIn="25" repeatDistanceUnits="MM" preserveRotation="1" dist="0" fitInPolygonOnly="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" offsetUnits="MM" overlapHandling="PreventOverlap" overrunDistance="0" prioritization="PreferCloser" lineAnchorType="0" yOffset="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGeneratorEnabled="0" lineAnchorTextPoint="FollowPlacement" lineAnchorClipping="0" quadOffset="4" maxCurvedCharAngleOut="-25" offsetType="0"/>
+      <rendering fontMinPixelSize="3" labelPerPart="0" obstacleType="1" scaleMax="0" mergeLines="0" scaleVisibility="0" maxNumLabels="2000" obstacleFactor="1" unplacedVisibility="0" zIndex="0" upsidedownLabels="0" fontLimitPixelSize="0" scaleMin="0" drawLabels="1" limitNumLabels="0" obstacle="1" fontMaxPixelSize="10000" minFeatureSize="0"/>
       <dd_properties>
         <Option type="Map">
           <Option name="name" type="QString" value=""/>
@@ -407,7 +269,7 @@
           <Option name="drawToAllParts" type="bool" value="false"/>
           <Option name="enabled" type="QString" value="0"/>
           <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"/>
-          <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; frame_rate=&quot;10&quot; type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer id=&quot;{7f395ec5-2e03-40ab-a071-df4a4fd4db6e}&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/>&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/>&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot;/>&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/>&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/>&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
+          <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; frame_rate=&quot;10&quot; type=&quot;line&quot; force_rhr=&quot;0&quot; clip_to_extent=&quot;1&quot; alpha=&quot;1&quot; is_animated=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer pass=&quot;0&quot; class=&quot;SimpleLine&quot; enabled=&quot;1&quot; locked=&quot;0&quot; id=&quot;{7f395ec5-2e03-40ab-a071-df4a4fd4db6e}&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/>&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/>&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot;/>&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/>&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/>&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
           <Option name="minLength" type="double" value="0"/>
           <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"/>
           <Option name="minLengthUnit" type="QString" value="MM"/>
@@ -421,36 +283,8 @@
       </callout>
     </settings>
   </labeling>
-  <customproperties>
-    <Option type="Map">
-      <Option name="embeddedWidgets/count" type="int" value="0"/>
-      <Option name="variableNames" type="StringList">
-        <Option type="QString" value="pzp_layer"/>
-        <Option type="QString" value="pzp_process"/>
-      </Option>
-      <Option name="variableValues" type="StringList">
-        <Option type="QString" value="area"/>
-        <Option type="QString" value="1110"/>
-      </Option>
-    </Option>
-  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
-  <layerOpacity>1</layerOpacity>
-  <geometryOptions removeDuplicateNodes="1" geometryPrecision="0.001">
-    <activeChecks type="StringList">
-      <Option type="QString" value="QgsIsValidCheck"/>
-    </activeChecks>
-    <checkConfiguration type="Map">
-      <Option name="QgsGeometryGapCheck" type="Map">
-        <Option name="allowedGapsBuffer" type="double" value="0"/>
-        <Option name="allowedGapsEnabled" type="bool" value="false"/>
-        <Option name="allowedGapsLayer" type="QString" value=""/>
-      </Option>
-    </checkConfiguration>
-  </geometryOptions>
-  <legend showLabelLegend="0" type="default-vector"/>
-  <referencedLayers/>
   <fieldConfiguration>
     <field name="fid" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
@@ -518,10 +352,10 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="fid" index="0"/>
-    <alias name="Nome" field="commento" index="1"/>
-    <alias name="Processo" field="proc_parz" index="2"/>
-    <alias name="Fonte processo" field="fonte_proc" index="3"/>
+    <alias field="fid" name="" index="0"/>
+    <alias field="commento" name="Nome" index="1"/>
+    <alias field="proc_parz" name="Processo" index="2"/>
+    <alias field="fonte_proc" name="Fonte processo" index="3"/>
   </aliases>
   <splitPolicies>
     <policy field="fid" policy="Duplicate"/>
@@ -536,41 +370,24 @@
     <policy field="fonte_proc" policy="Duplicate"/>
   </duplicatePolicies>
   <defaults>
-    <default expression="" field="fid" applyOnUpdate="0"/>
-    <default expression="" field="commento" applyOnUpdate="0"/>
-    <default expression="@pzp_process" field="proc_parz" applyOnUpdate="0"/>
-    <default expression="" field="fonte_proc" applyOnUpdate="0"/>
+    <default field="fid" expression="" applyOnUpdate="0"/>
+    <default field="commento" expression="" applyOnUpdate="0"/>
+    <default field="proc_parz" expression="@pzp_process" applyOnUpdate="0"/>
+    <default field="fonte_proc" expression="" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" field="fid" notnull_strength="1" constraints="3" unique_strength="1"/>
-    <constraint exp_strength="0" field="commento" notnull_strength="0" constraints="0" unique_strength="0"/>
-    <constraint exp_strength="1" field="proc_parz" notnull_strength="1" constraints="5" unique_strength="0"/>
-    <constraint exp_strength="0" field="fonte_proc" notnull_strength="1" constraints="3" unique_strength="1"/>
+    <constraint field="fid" unique_strength="1" exp_strength="0" constraints="3" notnull_strength="1"/>
+    <constraint field="commento" unique_strength="0" exp_strength="0" constraints="0" notnull_strength="0"/>
+    <constraint field="proc_parz" unique_strength="0" exp_strength="1" constraints="5" notnull_strength="1"/>
+    <constraint field="fonte_proc" unique_strength="1" exp_strength="1" constraints="7" notnull_strength="1"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="fid" desc=""/>
-    <constraint exp="" field="commento" desc=""/>
-    <constraint exp="" field="proc_parz" desc=""/>
-    <constraint exp="" field="fonte_proc" desc=""/>
+    <constraint field="fid" exp="" desc=""/>
+    <constraint field="commento" exp="" desc=""/>
+    <constraint field="proc_parz" exp="" desc=""/>
+    <constraint field="fonte_proc" exp="" desc=""/>
   </constraintExpressions>
   <expressionfields/>
-  <attributeactions>
-    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
-  </attributeactions>
-  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
-    <columns>
-      <column width="-1" name="commento" type="field" hidden="0"/>
-      <column width="-1" name="proc_parz" type="field" hidden="0"/>
-      <column width="-1" name="fonte_proc" type="field" hidden="0"/>
-      <column width="-1" name="fid" type="field" hidden="0"/>
-      <column width="-1" type="actions" hidden="1"/>
-    </columns>
-  </attributetableconfig>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <storedexpressions/>
   <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
@@ -595,26 +412,26 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <labelStyle labelColor="" overrideLabelFont="0" overrideLabelColor="0">
-      <labelFont description="Noto Sans,10,-1,0,50,0,0,0,0,0" style="" italic="0" strikethrough="0" underline="0" bold="0"/>
+    <labelStyle overrideLabelFont="0" overrideLabelColor="0" labelColor="">
+      <labelFont style="" bold="0" italic="0" underline="0" strikethrough="0" description="Noto Sans,10,-1,0,50,0,0,0,0,0"/>
     </labelStyle>
-    <attributeEditorContainer collapsedExpression="" visibilityExpression="" name="Attributi" groupBox="0" showLabel="1" type="Tab" horizontalStretch="0" verticalStretch="0" collapsedExpressionEnabled="0" columnCount="1" visibilityExpressionEnabled="0" collapsed="0">
-      <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-        <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" italic="0" strikethrough="0" underline="0" bold="0"/>
+    <attributeEditorContainer collapsed="0" name="Attributi" groupBox="0" collapsedExpression="" type="Tab" showLabel="1" columnCount="1" verticalStretch="0" visibilityExpressionEnabled="0" visibilityExpression="" horizontalStretch="0" collapsedExpressionEnabled="0">
+      <labelStyle overrideLabelFont="0" overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+        <labelFont style="" bold="0" italic="0" underline="0" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0"/>
       </labelStyle>
-      <attributeEditorField name="proc_parz" showLabel="1" horizontalStretch="0" verticalStretch="0" index="2">
-        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-          <labelFont description="Noto Sans,8.25,-1,5,50,0,0,0,0,0" style="" italic="0" strikethrough="0" underline="0" bold="0"/>
+      <attributeEditorField name="proc_parz" index="2" showLabel="1" verticalStretch="0" horizontalStretch="0">
+        <labelStyle overrideLabelFont="0" overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont style="" bold="0" italic="0" underline="0" strikethrough="0" description="Noto Sans,8.25,-1,5,50,0,0,0,0,0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField name="commento" showLabel="1" horizontalStretch="0" verticalStretch="0" index="1">
-        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-          <labelFont description="Noto Sans,8.25,-1,5,50,0,0,0,0,0" style="" italic="0" strikethrough="0" underline="0" bold="0"/>
+      <attributeEditorField name="commento" index="1" showLabel="1" verticalStretch="0" horizontalStretch="0">
+        <labelStyle overrideLabelFont="0" overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont style="" bold="0" italic="0" underline="0" strikethrough="0" description="Noto Sans,8.25,-1,5,50,0,0,0,0,0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField name="fonte_proc" showLabel="1" horizontalStretch="0" verticalStretch="0" index="3">
-        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
-          <labelFont description="Roboto,10,-1,0,50,0,0,0,0,0" style="" italic="0" strikethrough="0" underline="0" bold="0"/>
+      <attributeEditorField name="fonte_proc" index="3" showLabel="1" verticalStretch="0" horizontalStretch="0">
+        <labelStyle overrideLabelFont="0" overrideLabelColor="0" labelColor="0,0,0,255,rgb:0,0,0,1">
+          <labelFont style="" bold="0" italic="0" underline="0" strikethrough="0" description="Roboto,10,-1,0,50,0,0,0,0,0"/>
         </labelStyle>
       </attributeEditorField>
     </attributeEditorContainer>
@@ -640,6 +457,5 @@ def my_form_open(dialog, layer, feature):
   <dataDefinedFieldProperties/>
   <widgets/>
   <previewExpression>"commento"</previewExpression>
-  <mapTip enabled="1"></mapTip>
   <layerGeometryType>2</layerGeometryType>
 </qgis>

--- a/pzp/qml/area.qml
+++ b/pzp/qml/area.qml
@@ -1,111 +1,249 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="3.43.0-Master" readOnly="0" styleCategories="LayerConfiguration|Symbology|Labeling|Fields|Forms" labelsEnabled="1">
+<qgis labelsEnabled="1" version="3.42.2-Münster" simplifyDrawingTol="1" minScale="0" maxScale="0" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" simplifyDrawingHints="1" readOnly="0" simplifyMaxScale="1" symbologyReferenceScale="-1" autoRefreshMode="Disabled" autoRefreshTime="0" simplifyAlgorithm="0" simplifyLocal="1">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <renderer-v2 type="singleSymbol" referencescale="-1" forceraster="0" enableorderby="0" symbollevels="0">
-    <symbols>
-      <symbol type="fill" name="0" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+  <temporal durationUnit="min" accumulate="0" mode="0" startExpression="" limitMode="0" startField="" endField="" enabled="0" durationField="fid" endExpression="" fixedDuration="0">
+    <fixedRange>
+      <start></start>
+      <end></end>
+    </fixedRange>
+  </temporal>
+  <elevation symbology="Line" customToleranceEnabled="1" extrusion="0" type="IndividualFeatures" extrusionEnabled="0" clamping="Terrain" zoffset="0" zscale="1" binding="Centroid" respectLayerSymbol="1" showMarkerSymbolInSurfacePlots="0">
+    <data-defined-properties>
+      <Option type="Map">
+        <Option name="name" type="QString" value=""/>
+        <Option name="properties"/>
+        <Option name="type" type="QString" value="collection"/>
+      </Option>
+    </data-defined-properties>
+    <profileLineSymbol>
+      <symbol name="" frame_rate="10" type="line" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer id="{e2908301-c6cc-40b6-86af-baf59f9dbd5e}" pass="0" locked="0" enabled="1" class="SimpleFill">
+        <layer id="{397d7a2f-44c2-4134-8353-1d4111d56c85}" class="SimpleLine" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="0,0,255,0,rgb:0,0,1,0" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="31,120,250,255,rgb:0.12156862745098039,0.47058823529411764,0.98039215686274506,1" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.46" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option name="align_dash_pattern" type="QString" value="0"/>
+            <Option name="capstyle" type="QString" value="square"/>
+            <Option name="customdash" type="QString" value="5;2"/>
+            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="customdash_unit" type="QString" value="MM"/>
+            <Option name="dash_pattern_offset" type="QString" value="0"/>
+            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+            <Option name="draw_inside_polygon" type="QString" value="0"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="line_color" type="QString" value="190,178,151,255,rgb:0.74509803921568629,0.69803921568627447,0.59215686274509804,1"/>
+            <Option name="line_style" type="QString" value="solid"/>
+            <Option name="line_width" type="QString" value="0.6"/>
+            <Option name="line_width_unit" type="QString" value="MM"/>
+            <Option name="offset" type="QString" value="0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="ring_filter" type="QString" value="0"/>
+            <Option name="trim_distance_end" type="QString" value="0"/>
+            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+            <Option name="trim_distance_start" type="QString" value="0"/>
+            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+            <Option name="use_custom_dash" type="QString" value="0"/>
+            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer id="{fa66d403-2161-4206-abd4-5fa7fab3fc2c}" pass="0" locked="0" enabled="1" class="LinePatternFill">
+      </symbol>
+    </profileLineSymbol>
+    <profileFillSymbol>
+      <symbol name="" frame_rate="10" type="fill" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
+        <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="45" name="angle"/>
-            <Option type="QString" value="during_render" name="clip_mode"/>
-            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="color"/>
-            <Option type="QString" value="feature" name="coordinate_reference"/>
-            <Option type="QString" value="2" name="distance"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="distance_map_unit_scale"/>
-            <Option type="QString" value="MM" name="distance_unit"/>
-            <Option type="QString" value="0.5" name="line_width"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="line_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="line_width_unit"/>
-            <Option type="QString" value="0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{a52e8d0e-d914-49af-b8f6-b467fa93f585}" class="SimpleFill" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="190,178,151,255,rgb:0.74509803921568629,0.69803921568627447,0.59215686274509804,1"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="136,127,108,255,rgb:0.53220416571297779,0.49858854047455559,0.42296482795452811,1"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.2"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
-          <symbol type="line" name="@0@1" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+        </layer>
+      </symbol>
+    </profileFillSymbol>
+    <profileMarkerSymbol>
+      <symbol name="" frame_rate="10" type="marker" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{43d11b82-cdd8-4194-8362-f44bc9c8b460}" class="SimpleMarker" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="angle" type="QString" value="0"/>
+            <Option name="cap_style" type="QString" value="square"/>
+            <Option name="color" type="QString" value="190,178,151,255,rgb:0.74509803921568629,0.69803921568627447,0.59215686274509804,1"/>
+            <Option name="horizontal_anchor_point" type="QString" value="1"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="name" type="QString" value="diamond"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="136,127,108,255,rgb:0.53220416571297779,0.49858854047455559,0.42296482795452811,1"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.2"/>
+            <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="scale_method" type="QString" value="diameter"/>
+            <Option name="size" type="QString" value="3"/>
+            <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="size_unit" type="QString" value="MM"/>
+            <Option name="vertical_anchor_point" type="QString" value="1"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </profileMarkerSymbol>
+  </elevation>
+  <renderer-v2 symbollevels="0" enableorderby="0" type="singleSymbol" referencescale="-1" forceraster="0">
+    <symbols>
+      <symbol name="0" frame_rate="10" type="fill" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{e2908301-c6cc-40b6-86af-baf59f9dbd5e}" class="SimpleFill" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="0,0,255,0,rgb:0,0,1,0"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="31,120,250,255,rgb:0.12156862745098039,0.47058823529411764,0.98039215686274506,1"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.46"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer id="{fa66d403-2161-4206-abd4-5fa7fab3fc2c}" class="LinePatternFill" locked="0" enabled="1" pass="0">
+          <Option type="Map">
+            <Option name="angle" type="QString" value="45"/>
+            <Option name="clip_mode" type="QString" value="during_render"/>
+            <Option name="color" type="QString" value="0,0,0,255,rgb:0,0,0,1"/>
+            <Option name="coordinate_reference" type="QString" value="feature"/>
+            <Option name="distance" type="QString" value="2"/>
+            <Option name="distance_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="distance_unit" type="QString" value="MM"/>
+            <Option name="line_width" type="QString" value="0.5"/>
+            <Option name="line_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="line_width_unit" type="QString" value="MM"/>
+            <Option name="offset" type="QString" value="0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+          <symbol name="@0@1" frame_rate="10" type="line" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option name="name" type="QString" value=""/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option name="type" type="QString" value="collection"/>
               </Option>
             </data_defined_properties>
-            <layer id="{d5875839-1bb3-4e74-8b0b-85cca81b4357}" pass="0" locked="0" enabled="1" class="SimpleLine">
+            <layer id="{d5875839-1bb3-4e74-8b0b-85cca81b4357}" class="SimpleLine" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option type="QString" value="0" name="align_dash_pattern"/>
-                <Option type="QString" value="square" name="capstyle"/>
-                <Option type="QString" value="5;2" name="customdash"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-                <Option type="QString" value="MM" name="customdash_unit"/>
-                <Option type="QString" value="0" name="dash_pattern_offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-                <Option type="QString" value="0" name="draw_inside_polygon"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="31,120,180,255,rgb:0.12156862745098039,0.47058823529411764,0.70588235294117652,1" name="line_color"/>
-                <Option type="QString" value="solid" name="line_style"/>
-                <Option type="QString" value="0.15" name="line_width"/>
-                <Option type="QString" value="MM" name="line_width_unit"/>
-                <Option type="QString" value="0" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="offset_unit"/>
-                <Option type="QString" value="0" name="ring_filter"/>
-                <Option type="QString" value="0" name="trim_distance_end"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-                <Option type="QString" value="0" name="trim_distance_start"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-                <Option type="QString" value="0" name="use_custom_dash"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+                <Option name="align_dash_pattern" type="QString" value="0"/>
+                <Option name="capstyle" type="QString" value="square"/>
+                <Option name="customdash" type="QString" value="5;2"/>
+                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="customdash_unit" type="QString" value="MM"/>
+                <Option name="dash_pattern_offset" type="QString" value="0"/>
+                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+                <Option name="draw_inside_polygon" type="QString" value="0"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="line_color" type="QString" value="31,120,180,255,rgb:0.12156862745098039,0.47058823529411764,0.70588235294117652,1"/>
+                <Option name="line_style" type="QString" value="solid"/>
+                <Option name="line_width" type="QString" value="0.15"/>
+                <Option name="line_width_unit" type="QString" value="MM"/>
+                <Option name="offset" type="QString" value="0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="ring_filter" type="QString" value="0"/>
+                <Option name="trim_distance_end" type="QString" value="0"/>
+                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+                <Option name="trim_distance_start" type="QString" value="0"/>
+                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+                <Option name="use_custom_dash" type="QString" value="0"/>
+                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option name="name" type="QString" value=""/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="type" type="QString" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -117,42 +255,42 @@
     <sizescale/>
     <data-defined-properties>
       <Option type="Map">
-        <Option type="QString" value="" name="name"/>
+        <Option name="name" type="QString" value=""/>
         <Option name="properties"/>
-        <Option type="QString" value="collection" name="type"/>
+        <Option name="type" type="QString" value="collection"/>
       </Option>
     </data-defined-properties>
   </renderer-v2>
   <selection mode="Default">
     <selectionColor invalid="1"/>
     <selectionSymbol>
-      <symbol type="fill" name="" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+      <symbol name="" frame_rate="10" type="fill" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer id="{6b17d3ff-6506-4e7d-b467-92ae3d6174ac}" pass="0" locked="0" enabled="1" class="SimpleFill">
+        <layer id="{6b17d3ff-6506-4e7d-b467-92ae3d6174ac}" class="SimpleFill" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-            <Option type="QString" value="0,0,255,255,rgb:0,0,1,1" name="color"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0.26" name="outline_width"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="solid" name="style"/>
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="0,0,255,255,rgb:0,0,1,1"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.26"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
           </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -161,130 +299,158 @@
   </selection>
   <labeling type="simple">
     <settings calloutType="simple">
-      <text-style fontUnderline="0" fontFamily="Open Sans" fontItalic="0" fontKerning="1" namedStyle="Regular" tabStopDistance="80" fontWordSpacing="0" isExpression="0" multilineHeight="1" allowHtml="0" fontStrikeout="0" forcedItalic="0" textOpacity="1" textColor="50,50,50,255,rgb:0.19607843137254902,0.19607843137254902,0.19607843137254902,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" fontSize="10" tabStopDistanceUnit="Point" legendString="Aa" fontSizeUnit="Point" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedBold="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" textOrientation="horizontal" blendMode="0" fieldName="commento" capitalization="0" useSubstitutions="0" fontWeight="50" fontLetterSpacing="0" multilineHeightUnit="Percentage">
+      <text-style fontFamily="Open Sans" textOrientation="horizontal" multilineHeightUnit="Percentage" tabStopDistance="80" namedStyle="Regular" fontWeight="50" fontUnderline="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontWordSpacing="0" fontStrikeout="0" fontLetterSpacing="0" multilineHeight="1" fontItalic="0" fontKerning="1" allowHtml="0" textOpacity="1" fontSizeUnit="Point" isExpression="0" capitalization="0" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" useSubstitutions="0" fieldName="commento" textColor="50,50,50,255,rgb:0.19607843137254902,0.19607843137254902,0.19607843137254902,1" fontSize="10" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" tabStopDistanceUnit="Point" legendString="Aa" forcedBold="0" forcedItalic="0" blendMode="0">
         <families/>
-        <text-buffer bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferColor="250,250,250,255,rgb:0.98039215686274506,0.98039215686274506,0.98039215686274506,1" bufferOpacity="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="128" bufferDraw="0" bufferSizeUnits="MM"/>
-        <text-mask maskEnabled="0" maskJoinStyle="128" maskSizeUnits="MM" maskType="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskedSymbolLayers="" maskSize="1.5" maskSize2="1.5" maskOpacity="1"/>
-        <background shapeRadiiY="0" shapeJoinStyle="64" shapeBorderWidthUnit="Point" shapeRadiiX="0" shapeBlendMode="0" shapeType="0" shapeSizeY="0" shapeOffsetUnit="Point" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRotation="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeBorderWidth="0" shapeOffsetX="0" shapeSizeUnit="Point" shapeSizeX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0" shapeSizeType="0" shapeRadiiUnit="Point" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeOffsetY="0" shapeSVGFile="" shapeOpacity="1">
-          <symbol type="marker" name="markerSymbol" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+        <text-buffer bufferSizeUnits="MM" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferColor="250,250,250,255,rgb:0.98039215686274506,0.98039215686274506,0.98039215686274506,1" bufferOpacity="1" bufferJoinStyle="128" bufferSize="1" bufferDraw="0" bufferNoFill="1" bufferBlendMode="0"/>
+        <text-mask maskType="0" maskSize2="1.5" maskSizeUnits="MM" maskJoinStyle="128" maskEnabled="0" maskedSymbolLayers="" maskSize="1.5" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskOpacity="1"/>
+        <background shapeSizeY="0" shapeBlendMode="0" shapeRadiiY="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeSizeUnit="Point" shapeOffsetX="0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRotation="0" shapeDraw="0" shapeSizeType="0" shapeBorderWidth="0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiUnit="Point" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="Point" shapeRotationType="0" shapeType="0" shapeOpacity="1" shapeOffsetUnit="Point" shapeSizeX="0" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeOffsetY="0" shapeJoinStyle="64" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0">
+          <symbol name="markerSymbol" frame_rate="10" type="marker" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option name="name" type="QString" value=""/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option name="type" type="QString" value="collection"/>
               </Option>
             </data_defined_properties>
-            <layer id="" pass="0" locked="0" enabled="1" class="SimpleMarker">
+            <layer id="" class="SimpleMarker" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option type="QString" value="0" name="angle"/>
-                <Option type="QString" value="square" name="cap_style"/>
-                <Option type="QString" value="190,207,80,255,rgb:0.74509803921568629,0.81176470588235294,0.31372549019607843,1" name="color"/>
-                <Option type="QString" value="1" name="horizontal_anchor_point"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="circle" name="name"/>
-                <Option type="QString" value="0,0" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="offset_unit"/>
-                <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
-                <Option type="QString" value="solid" name="outline_style"/>
-                <Option type="QString" value="0" name="outline_width"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-                <Option type="QString" value="MM" name="outline_width_unit"/>
-                <Option type="QString" value="diameter" name="scale_method"/>
-                <Option type="QString" value="2" name="size"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
-                <Option type="QString" value="MM" name="size_unit"/>
-                <Option type="QString" value="1" name="vertical_anchor_point"/>
+                <Option name="angle" type="QString" value="0"/>
+                <Option name="cap_style" type="QString" value="square"/>
+                <Option name="color" type="QString" value="190,207,80,255,rgb:0.74509803921568629,0.81176470588235294,0.31372549019607843,1"/>
+                <Option name="horizontal_anchor_point" type="QString" value="1"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="name" type="QString" value="circle"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1"/>
+                <Option name="outline_style" type="QString" value="solid"/>
+                <Option name="outline_width" type="QString" value="0"/>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="outline_width_unit" type="QString" value="MM"/>
+                <Option name="scale_method" type="QString" value="diameter"/>
+                <Option name="size" type="QString" value="2"/>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="size_unit" type="QString" value="MM"/>
+                <Option name="vertical_anchor_point" type="QString" value="1"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option name="name" type="QString" value=""/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="type" type="QString" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
-          <symbol type="fill" name="fillSymbol" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+          <symbol name="fillSymbol" frame_rate="10" type="fill" alpha="1" clip_to_extent="1" is_animated="0" force_rhr="0">
             <data_defined_properties>
               <Option type="Map">
-                <Option type="QString" value="" name="name"/>
+                <Option name="name" type="QString" value=""/>
                 <Option name="properties"/>
-                <Option type="QString" value="collection" name="type"/>
+                <Option name="type" type="QString" value="collection"/>
               </Option>
             </data_defined_properties>
-            <layer id="" pass="0" locked="0" enabled="1" class="SimpleFill">
+            <layer id="" class="SimpleFill" locked="0" enabled="1" pass="0">
               <Option type="Map">
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
-                <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
-                <Option type="QString" value="bevel" name="joinstyle"/>
-                <Option type="QString" value="0,0" name="offset"/>
-                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-                <Option type="QString" value="MM" name="offset_unit"/>
-                <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
-                <Option type="QString" value="no" name="outline_style"/>
-                <Option type="QString" value="0" name="outline_width"/>
-                <Option type="QString" value="Point" name="outline_width_unit"/>
-                <Option type="QString" value="solid" name="style"/>
+                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="color" type="QString" value="255,255,255,255,rgb:1,1,1,1"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1"/>
+                <Option name="outline_style" type="QString" value="no"/>
+                <Option name="outline_width" type="QString" value="0"/>
+                <Option name="outline_width_unit" type="QString" value="Point"/>
+                <Option name="style" type="QString" value="solid"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option name="name" type="QString" value=""/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="type" type="QString" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </background>
-        <shadow shadowDraw="0" shadowRadiusAlphaOnly="0" shadowOpacity="0.69999999999999996" shadowUnder="0" shadowRadiusUnit="MM" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetUnit="MM" shadowOffsetDist="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
+        <shadow shadowOffsetAngle="135" shadowRadius="1.5" shadowUnder="0" shadowBlendMode="6" shadowRadiusUnit="MM" shadowRadiusAlphaOnly="0" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowDraw="0" shadowOffsetUnit="MM" shadowOffsetDist="1" shadowOpacity="0.69999999999999996" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetGlobal="1" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
         <dd_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </dd_properties>
         <substitutions/>
       </text-style>
-      <text-format rightDirectionSymbol=">" decimals="3" plussign="0" useMaxLineLengthForAutoWrap="1" leftDirectionSymbol="&lt;" addDirectionSymbol="0" autoWrapLength="0" formatNumbers="0" multilineAlign="3" wrapChar="" reverseDirectionSymbol="0" placeDirectionSymbol="0"/>
-      <placement lineAnchorPercent="0.5" repeatDistanceUnits="MM" rotationUnit="AngleDegrees" overlapHandling="PreventOverlap" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidWhole="0" repeatDistance="0" rotationAngle="0" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="10" offsetUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" overrunDistance="0" geometryGeneratorType="PointGeometry" placement="0" offsetType="0" distUnits="MM" lineAnchorClipping="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" lineAnchorType="0" allowDegraded="0" dist="0" geometryGeneratorEnabled="0" centroidInside="0" maximumDistance="0" geometryGenerator="" maximumDistanceUnit="MM" yOffset="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" lineAnchorTextPoint="FollowPlacement" maxCurvedCharAngleOut="-25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" maxCurvedCharAngleIn="25" quadOffset="4" fitInPolygonOnly="0" layerType="PolygonGeometry" prioritization="PreferCloser" priority="5" overrunDistanceUnit="MM" polygonPlacementFlags="2"/>
-      <rendering fontMinPixelSize="3" scaleMax="0" minFeatureSize="0" upsidedownLabels="0" fontMaxPixelSize="10000" fontLimitPixelSize="0" obstacleType="1" labelPerPart="0" drawLabels="1" obstacleFactor="1" scaleVisibility="0" scaleMin="0" obstacle="1" maxNumLabels="2000" limitNumLabels="0" mergeLines="0" zIndex="0" unplacedVisibility="0"/>
+      <text-format addDirectionSymbol="0" placeDirectionSymbol="0" rightDirectionSymbol=">" multilineAlign="3" formatNumbers="0" plussign="0" leftDirectionSymbol="&lt;" useMaxLineLengthForAutoWrap="1" decimals="3" reverseDirectionSymbol="0" wrapChar="" autoWrapLength="0"/>
+      <placement placement="0" repeatDistanceUnits="MM" yOffset="0" maximumDistance="0" distMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" lineAnchorTextPoint="FollowPlacement" distUnits="MM" maxCurvedCharAngleIn="25" preserveRotation="1" maximumDistanceUnit="MM" offsetType="0" overrunDistance="0" xOffset="0" rotationUnit="AngleDegrees" quadOffset="4" offsetUnits="MM" placementFlags="10" geometryGeneratorType="PointGeometry" centroidWhole="0" geometryGenerator="" centroidInside="0" lineAnchorClipping="0" geometryGeneratorEnabled="0" overlapHandling="PreventOverlap" lineAnchorType="0" lineAnchorPercent="0.5" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" allowDegraded="0" prioritization="PreferCloser" overrunDistanceUnit="MM" layerType="PolygonGeometry" polygonPlacementFlags="2" rotationAngle="0" maxCurvedCharAngleOut="-25" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" repeatDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" dist="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" priority="5"/>
+      <rendering upsidedownLabels="0" drawLabels="1" unplacedVisibility="0" labelPerPart="0" scaleVisibility="0" obstacleType="1" mergeLines="0" limitNumLabels="0" fontMinPixelSize="3" fontMaxPixelSize="10000" obstacle="1" fontLimitPixelSize="0" zIndex="0" scaleMax="0" minFeatureSize="0" maxNumLabels="2000" obstacleFactor="1" scaleMin="0"/>
       <dd_properties>
         <Option type="Map">
-          <Option type="QString" value="" name="name"/>
+          <Option name="name" type="QString" value=""/>
           <Option name="properties"/>
-          <Option type="QString" value="collection" name="type"/>
+          <Option name="type" type="QString" value="collection"/>
         </Option>
       </dd_properties>
       <callout type="simple">
         <Option type="Map">
-          <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
-          <Option type="int" value="0" name="blendMode"/>
-          <Option type="Map" name="ddProperties">
-            <Option type="QString" value="" name="name"/>
+          <Option name="anchorPoint" type="QString" value="pole_of_inaccessibility"/>
+          <Option name="blendMode" type="int" value="0"/>
+          <Option name="ddProperties" type="Map">
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
-          <Option type="bool" value="false" name="drawToAllParts"/>
-          <Option type="QString" value="0" name="enabled"/>
-          <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
-          <Option type="QString" value="&lt;symbol type=&quot;line&quot; name=&quot;symbol&quot; frame_rate=&quot;10&quot; is_animated=&quot;0&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer id=&quot;{7f395ec5-2e03-40ab-a071-df4a4fd4db6e}&quot; pass=&quot;0&quot; locked=&quot;0&quot; enabled=&quot;1&quot; class=&quot;SimpleLine&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
-          <Option type="double" value="0" name="minLength"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
-          <Option type="QString" value="MM" name="minLengthUnit"/>
-          <Option type="double" value="0" name="offsetFromAnchor"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
-          <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
-          <Option type="double" value="0" name="offsetFromLabel"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
-          <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
+          <Option name="drawToAllParts" type="bool" value="false"/>
+          <Option name="enabled" type="QString" value="0"/>
+          <Option name="labelAnchorPoint" type="QString" value="point_on_exterior"/>
+          <Option name="lineSymbol" type="QString" value="&lt;symbol name=&quot;symbol&quot; frame_rate=&quot;10&quot; type=&quot;line&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; is_animated=&quot;0&quot; force_rhr=&quot;0&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer id=&quot;{7f395ec5-2e03-40ab-a071-df4a4fd4db6e}&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot; enabled=&quot;1&quot; pass=&quot;0&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;align_dash_pattern&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;capstyle&quot; type=&quot;QString&quot; value=&quot;square&quot;/>&lt;Option name=&quot;customdash&quot; type=&quot;QString&quot; value=&quot;5;2&quot;/>&lt;Option name=&quot;customdash_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;customdash_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;dash_pattern_offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;dash_pattern_offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;dash_pattern_offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;draw_inside_polygon&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;joinstyle&quot; type=&quot;QString&quot; value=&quot;bevel&quot;/>&lt;Option name=&quot;line_color&quot; type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot;/>&lt;Option name=&quot;line_style&quot; type=&quot;QString&quot; value=&quot;solid&quot;/>&lt;Option name=&quot;line_width&quot; type=&quot;QString&quot; value=&quot;0.3&quot;/>&lt;Option name=&quot;line_width_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;offset&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;offset_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;offset_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;ring_filter&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_end_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_end_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;trim_distance_start&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;trim_distance_start_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;Option name=&quot;trim_distance_start_unit&quot; type=&quot;QString&quot; value=&quot;MM&quot;/>&lt;Option name=&quot;tweak_dash_pattern_on_corners&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;use_custom_dash&quot; type=&quot;QString&quot; value=&quot;0&quot;/>&lt;Option name=&quot;width_map_unit_scale&quot; type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option name=&quot;name&quot; type=&quot;QString&quot; value=&quot;&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option name=&quot;type&quot; type=&quot;QString&quot; value=&quot;collection&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>"/>
+          <Option name="minLength" type="double" value="0"/>
+          <Option name="minLengthMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="minLengthUnit" type="QString" value="MM"/>
+          <Option name="offsetFromAnchor" type="double" value="0"/>
+          <Option name="offsetFromAnchorMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offsetFromAnchorUnit" type="QString" value="MM"/>
+          <Option name="offsetFromLabel" type="double" value="0"/>
+          <Option name="offsetFromLabelMapUnitScale" type="QString" value="3x:0,0,0,0,0,0"/>
+          <Option name="offsetFromLabelUnit" type="QString" value="MM"/>
         </Option>
       </callout>
     </settings>
   </labeling>
+  <customproperties>
+    <Option type="Map">
+      <Option name="embeddedWidgets/count" type="int" value="0"/>
+      <Option name="variableNames" type="StringList">
+        <Option type="QString" value="pzp_layer"/>
+        <Option type="QString" value="pzp_process"/>
+      </Option>
+      <Option name="variableValues" type="StringList">
+        <Option type="QString" value="area"/>
+        <Option type="QString" value="1110"/>
+      </Option>
+    </Option>
+  </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <geometryOptions removeDuplicateNodes="1" geometryPrecision="0.001">
+    <activeChecks type="StringList">
+      <Option type="QString" value="QgsIsValidCheck"/>
+    </activeChecks>
+    <checkConfiguration type="Map">
+      <Option name="QgsGeometryGapCheck" type="Map">
+        <Option name="allowedGapsBuffer" type="double" value="0"/>
+        <Option name="allowedGapsEnabled" type="bool" value="false"/>
+        <Option name="allowedGapsLayer" type="QString" value=""/>
+      </Option>
+    </checkConfiguration>
+  </geometryOptions>
+  <legend showLabelLegend="0" type="default-vector"/>
+  <referencedLayers/>
   <fieldConfiguration>
     <field name="fid" configurationFlags="NoFlag">
       <editWidget type="TextEdit">
@@ -297,8 +463,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
@@ -307,33 +473,33 @@
       <editWidget type="ValueMap">
         <config>
           <Option type="Map">
-            <Option type="List" name="map">
+            <Option name="map" type="List">
               <Option type="Map">
-                <Option type="QString" value="1110" name="Alluvionamento corso d'acqua minore"/>
+                <Option name="Alluvionamento corso d'acqua minore" type="QString" value="1110"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1120" name="Alluvionamento corso d'acqua principale"/>
+                <Option name="Alluvionamento corso d'acqua principale" type="QString" value="1120"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="2002" name="Colata detritica di versante"/>
+                <Option name="Colata detritica di versante" type="QString" value="2002"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1200" name="Flusso detrito"/>
+                <Option name="Flusso detrito" type="QString" value="1200"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="1400" name="Ruscellamento superficiale"/>
+                <Option name="Ruscellamento superficiale" type="QString" value="1400"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="2001" name="Scivolamento spontaneo"/>
+                <Option name="Scivolamento spontaneo" type="QString" value="2001"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="3000" name="Caduta sassi o blocchi"/>
+                <Option name="Caduta sassi o blocchi" type="QString" value="3000"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="4100" name="Valanga radente"/>
+                <Option name="Valanga radente" type="QString" value="4100"/>
               </Option>
               <Option type="Map">
-                <Option type="QString" value="4200" name="Valanga polverosa"/>
+                <Option name="Valanga polverosa" type="QString" value="4200"/>
               </Option>
             </Option>
           </Option>
@@ -341,32 +507,21 @@
       </editWidget>
     </field>
     <field name="fonte_proc" configurationFlags="NoFlag">
-      <editWidget type="ValueRelation">
+      <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="AllowMulti"/>
-            <Option type="bool" value="false" name="AllowNull"/>
-            <Option type="invalid" name="Description"/>
-            <Option type="invalid" name="FilterExpression"/>
-            <Option type="QString" value="fonte_proc" name="Key"/>
-            <Option type="QString" value="Zone_instabilita_1ed06e0b_ac25_48cb_a1ae_d42c8a2f4097" name="Layer"/>
-            <Option type="QString" value="Zona sorgente (fonte processo)" name="LayerName"/>
-            <Option type="QString" value="ogr" name="LayerProviderName"/>
-            <Option type="QString" value="F:/UPIP/06_StrumentiGis/02_Progetti base/09_Plugin QGIS/01_Test QGIS/Mod.proc.CadutaSassi2024/data_3000_19092023_145610.gpkg|layername=Zone_instabilita" name="LayerSource"/>
-            <Option type="int" value="1" name="NofColumns"/>
-            <Option type="bool" value="false" name="OrderByValue"/>
-            <Option type="bool" value="false" name="UseCompleter"/>
-            <Option type="QString" value="fonte_proc" name="Value"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="fid" name="" index="0"/>
-    <alias field="commento" name="Nome" index="1"/>
-    <alias field="proc_parz" name="Processo" index="2"/>
-    <alias field="fonte_proc" name="Fonte processo" index="3"/>
+    <alias name="" field="fid" index="0"/>
+    <alias name="Nome" field="commento" index="1"/>
+    <alias name="Processo" field="proc_parz" index="2"/>
+    <alias name="Fonte processo" field="fonte_proc" index="3"/>
   </aliases>
   <splitPolicies>
     <policy field="fid" policy="Duplicate"/>
@@ -381,16 +536,16 @@
     <policy field="fonte_proc" policy="Duplicate"/>
   </duplicatePolicies>
   <defaults>
-    <default field="fid" applyOnUpdate="0" expression=""/>
-    <default field="commento" applyOnUpdate="0" expression=""/>
-    <default field="proc_parz" applyOnUpdate="0" expression="@pzp_process"/>
-    <default field="fonte_proc" applyOnUpdate="0" expression=""/>
+    <default expression="" field="fid" applyOnUpdate="0"/>
+    <default expression="" field="commento" applyOnUpdate="0"/>
+    <default expression="@pzp_process" field="proc_parz" applyOnUpdate="0"/>
+    <default expression="" field="fonte_proc" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint constraints="3" notnull_strength="1" field="fid" exp_strength="0" unique_strength="1"/>
-    <constraint constraints="0" notnull_strength="0" field="commento" exp_strength="0" unique_strength="0"/>
-    <constraint constraints="1" notnull_strength="1" field="proc_parz" exp_strength="0" unique_strength="0"/>
-    <constraint constraints="0" notnull_strength="0" field="fonte_proc" exp_strength="0" unique_strength="0"/>
+    <constraint exp_strength="0" field="fid" notnull_strength="1" constraints="3" unique_strength="1"/>
+    <constraint exp_strength="0" field="commento" notnull_strength="0" constraints="0" unique_strength="0"/>
+    <constraint exp_strength="1" field="proc_parz" notnull_strength="1" constraints="5" unique_strength="0"/>
+    <constraint exp_strength="0" field="fonte_proc" notnull_strength="1" constraints="3" unique_strength="1"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="fid" desc=""/>
@@ -399,6 +554,23 @@
     <constraint exp="" field="fonte_proc" desc=""/>
   </constraintExpressions>
   <expressionfields/>
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+  </attributeactions>
+  <attributetableconfig sortExpression="" actionWidgetStyle="dropDown" sortOrder="0">
+    <columns>
+      <column width="-1" name="commento" type="field" hidden="0"/>
+      <column width="-1" name="proc_parz" type="field" hidden="0"/>
+      <column width="-1" name="fonte_proc" type="field" hidden="0"/>
+      <column width="-1" name="fid" type="field" hidden="0"/>
+      <column width="-1" type="actions" hidden="1"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
   <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
@@ -423,26 +595,26 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <labelStyle labelColor="" overrideLabelColor="0" overrideLabelFont="0">
-      <labelFont italic="0" bold="0" style="" strikethrough="0" description="Ubuntu Sans,11,-1,5,50,0,0,0,0,0" underline="0"/>
+    <labelStyle labelColor="" overrideLabelFont="0" overrideLabelColor="0">
+      <labelFont description="Noto Sans,10,-1,0,50,0,0,0,0,0" style="" italic="0" strikethrough="0" underline="0" bold="0"/>
     </labelStyle>
-    <attributeEditorContainer type="Tab" collapsedExpressionEnabled="0" name="Attributi" showLabel="1" collapsedExpression="" verticalStretch="0" groupBox="0" collapsed="0" columnCount="1" visibilityExpression="" horizontalStretch="0" visibilityExpressionEnabled="0">
-      <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
-        <labelFont italic="0" bold="0" style="" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+    <attributeEditorContainer collapsedExpression="" visibilityExpression="" name="Attributi" groupBox="0" showLabel="1" type="Tab" horizontalStretch="0" verticalStretch="0" collapsedExpressionEnabled="0" columnCount="1" visibilityExpressionEnabled="0" collapsed="0">
+      <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+        <labelFont description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" style="" italic="0" strikethrough="0" underline="0" bold="0"/>
       </labelStyle>
-      <attributeEditorField name="proc_parz" showLabel="1" verticalStretch="0" horizontalStretch="0" index="2">
-        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
-          <labelFont italic="0" bold="0" style="" strikethrough="0" description="Noto Sans,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+      <attributeEditorField name="proc_parz" showLabel="1" horizontalStretch="0" verticalStretch="0" index="2">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+          <labelFont description="Noto Sans,8.25,-1,5,50,0,0,0,0,0" style="" italic="0" strikethrough="0" underline="0" bold="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField name="commento" showLabel="1" verticalStretch="0" horizontalStretch="0" index="1">
-        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
-          <labelFont italic="0" bold="0" style="" strikethrough="0" description="Noto Sans,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+      <attributeEditorField name="commento" showLabel="1" horizontalStretch="0" verticalStretch="0" index="1">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+          <labelFont description="Noto Sans,8.25,-1,5,50,0,0,0,0,0" style="" italic="0" strikethrough="0" underline="0" bold="0"/>
         </labelStyle>
       </attributeEditorField>
-      <attributeEditorField name="fonte_proc" showLabel="1" verticalStretch="0" horizontalStretch="0" index="3">
-        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
-          <labelFont italic="0" bold="0" style="" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+      <attributeEditorField name="fonte_proc" showLabel="1" horizontalStretch="0" verticalStretch="0" index="3">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelFont="0" overrideLabelColor="0">
+          <labelFont description="Roboto,10,-1,0,50,0,0,0,0,0" style="" italic="0" strikethrough="0" underline="0" bold="0"/>
         </labelStyle>
       </attributeEditorField>
     </attributeEditorContainer>
@@ -468,5 +640,6 @@ def my_form_open(dialog, layer, feature):
   <dataDefinedFieldProperties/>
   <widgets/>
   <previewExpression>"commento"</previewExpression>
+  <mapTip enabled="1"></mapTip>
   <layerGeometryType>2</layerGeometryType>
 </qgis>

--- a/pzp/qml/area_caduta_sassi.qml
+++ b/pzp/qml/area_caduta_sassi.qml
@@ -1,0 +1,472 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.43.0-Master" readOnly="0" styleCategories="LayerConfiguration|Symbology|Labeling|Fields|Forms" labelsEnabled="1">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <renderer-v2 type="singleSymbol" referencescale="-1" forceraster="0" enableorderby="0" symbollevels="0">
+    <symbols>
+      <symbol type="fill" name="0" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{e2908301-c6cc-40b6-86af-baf59f9dbd5e}" pass="0" locked="0" enabled="1" class="SimpleFill">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,0,255,0,rgb:0,0,1,0" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="31,120,250,255,rgb:0.12156862745098039,0.47058823529411764,0.98039215686274506,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.46" name="outline_width"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+        <layer id="{fa66d403-2161-4206-abd4-5fa7fab3fc2c}" pass="0" locked="0" enabled="1" class="LinePatternFill">
+          <Option type="Map">
+            <Option type="QString" value="45" name="angle"/>
+            <Option type="QString" value="during_render" name="clip_mode"/>
+            <Option type="QString" value="0,0,0,255,rgb:0,0,0,1" name="color"/>
+            <Option type="QString" value="feature" name="coordinate_reference"/>
+            <Option type="QString" value="2" name="distance"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="distance_map_unit_scale"/>
+            <Option type="QString" value="MM" name="distance_unit"/>
+            <Option type="QString" value="0.5" name="line_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="line_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="line_width_unit"/>
+            <Option type="QString" value="0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+          <symbol type="line" name="@0@1" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer id="{d5875839-1bb3-4e74-8b0b-85cca81b4357}" pass="0" locked="0" enabled="1" class="SimpleLine">
+              <Option type="Map">
+                <Option type="QString" value="0" name="align_dash_pattern"/>
+                <Option type="QString" value="square" name="capstyle"/>
+                <Option type="QString" value="5;2" name="customdash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+                <Option type="QString" value="MM" name="customdash_unit"/>
+                <Option type="QString" value="0" name="dash_pattern_offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+                <Option type="QString" value="0" name="draw_inside_polygon"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="31,120,180,255,rgb:0.12156862745098039,0.47058823529411764,0.70588235294117652,1" name="line_color"/>
+                <Option type="QString" value="solid" name="line_style"/>
+                <Option type="QString" value="0.15" name="line_width"/>
+                <Option type="QString" value="MM" name="line_width_unit"/>
+                <Option type="QString" value="0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="0" name="ring_filter"/>
+                <Option type="QString" value="0" name="trim_distance_end"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+                <Option type="QString" value="0" name="trim_distance_start"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+                <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+                <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+                <Option type="QString" value="0" name="use_custom_dash"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+    <data-defined-properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </data-defined-properties>
+  </renderer-v2>
+  <selection mode="Default">
+    <selectionColor invalid="1"/>
+    <selectionSymbol>
+      <symbol type="fill" name="" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer id="{6b17d3ff-6506-4e7d-b467-92ae3d6174ac}" pass="0" locked="0" enabled="1" class="SimpleFill">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="0,0,255,255,rgb:0,0,1,1" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0.26" name="outline_width"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </selectionSymbol>
+  </selection>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style fontUnderline="0" fontFamily="Open Sans" fontItalic="0" fontKerning="1" namedStyle="Regular" tabStopDistance="80" fontWordSpacing="0" isExpression="0" multilineHeight="1" allowHtml="0" fontStrikeout="0" forcedItalic="0" textOpacity="1" textColor="50,50,50,255,rgb:0.19607843137254902,0.19607843137254902,0.19607843137254902,1" tabStopDistanceMapUnitScale="3x:0,0,0,0,0,0" fontSize="10" tabStopDistanceUnit="Point" legendString="Aa" fontSizeUnit="Point" fontSizeMapUnitScale="3x:0,0,0,0,0,0" forcedBold="0" previewBkgrdColor="255,255,255,255,rgb:1,1,1,1" textOrientation="horizontal" blendMode="0" fieldName="commento" capitalization="0" useSubstitutions="0" fontWeight="50" fontLetterSpacing="0" multilineHeightUnit="Percentage">
+        <families/>
+        <text-buffer bufferSize="1" bufferBlendMode="0" bufferNoFill="1" bufferColor="250,250,250,255,rgb:0.98039215686274506,0.98039215686274506,0.98039215686274506,1" bufferOpacity="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferJoinStyle="128" bufferDraw="0" bufferSizeUnits="MM"/>
+        <text-mask maskEnabled="0" maskJoinStyle="128" maskSizeUnits="MM" maskType="0" maskSizeMapUnitScale="3x:0,0,0,0,0,0" maskedSymbolLayers="" maskSize="1.5" maskSize2="1.5" maskOpacity="1"/>
+        <background shapeRadiiY="0" shapeJoinStyle="64" shapeBorderWidthUnit="Point" shapeRadiiX="0" shapeBlendMode="0" shapeType="0" shapeSizeY="0" shapeOffsetUnit="Point" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeRotation="0" shapeFillColor="255,255,255,255,rgb:1,1,1,1" shapeBorderWidth="0" shapeOffsetX="0" shapeSizeUnit="Point" shapeSizeX="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeDraw="0" shapeSizeType="0" shapeRadiiUnit="Point" shapeBorderColor="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" shapeOffsetY="0" shapeSVGFile="" shapeOpacity="1">
+          <symbol type="marker" name="markerSymbol" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer id="" pass="0" locked="0" enabled="1" class="SimpleMarker">
+              <Option type="Map">
+                <Option type="QString" value="0" name="angle"/>
+                <Option type="QString" value="square" name="cap_style"/>
+                <Option type="QString" value="190,207,80,255,rgb:0.74509803921568629,0.81176470588235294,0.31372549019607843,1" name="color"/>
+                <Option type="QString" value="1" name="horizontal_anchor_point"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="circle" name="name"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="35,35,35,255,rgb:0.13725490196078433,0.13725490196078433,0.13725490196078433,1" name="outline_color"/>
+                <Option type="QString" value="solid" name="outline_style"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+                <Option type="QString" value="MM" name="outline_width_unit"/>
+                <Option type="QString" value="diameter" name="scale_method"/>
+                <Option type="QString" value="2" name="size"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+                <Option type="QString" value="MM" name="size_unit"/>
+                <Option type="QString" value="1" name="vertical_anchor_point"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+          <symbol type="fill" name="fillSymbol" frame_rate="10" is_animated="0" force_rhr="0" alpha="1" clip_to_extent="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option type="QString" value="" name="name"/>
+                <Option name="properties"/>
+                <Option type="QString" value="collection" name="type"/>
+              </Option>
+            </data_defined_properties>
+            <layer id="" pass="0" locked="0" enabled="1" class="SimpleFill">
+              <Option type="Map">
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+                <Option type="QString" value="255,255,255,255,rgb:1,1,1,1" name="color"/>
+                <Option type="QString" value="bevel" name="joinstyle"/>
+                <Option type="QString" value="0,0" name="offset"/>
+                <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+                <Option type="QString" value="MM" name="offset_unit"/>
+                <Option type="QString" value="128,128,128,255,rgb:0.50196078431372548,0.50196078431372548,0.50196078431372548,1" name="outline_color"/>
+                <Option type="QString" value="no" name="outline_style"/>
+                <Option type="QString" value="0" name="outline_width"/>
+                <Option type="QString" value="Point" name="outline_width_unit"/>
+                <Option type="QString" value="solid" name="style"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowDraw="0" shadowRadiusAlphaOnly="0" shadowOpacity="0.69999999999999996" shadowUnder="0" shadowRadiusUnit="MM" shadowColor="0,0,0,255,rgb:0,0,0,1" shadowOffsetAngle="135" shadowScale="100" shadowBlendMode="6" shadowOffsetUnit="MM" shadowOffsetDist="1" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetGlobal="1" shadowRadius="1.5" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format rightDirectionSymbol=">" decimals="3" plussign="0" useMaxLineLengthForAutoWrap="1" leftDirectionSymbol="&lt;" addDirectionSymbol="0" autoWrapLength="0" formatNumbers="0" multilineAlign="3" wrapChar="" reverseDirectionSymbol="0" placeDirectionSymbol="0"/>
+      <placement lineAnchorPercent="0.5" repeatDistanceUnits="MM" rotationUnit="AngleDegrees" overlapHandling="PreventOverlap" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" preserveRotation="1" centroidWhole="0" repeatDistance="0" rotationAngle="0" maximumDistanceMapUnitScale="3x:0,0,0,0,0,0" placementFlags="10" offsetUnits="MM" distMapUnitScale="3x:0,0,0,0,0,0" overrunDistance="0" geometryGeneratorType="PointGeometry" placement="0" offsetType="0" distUnits="MM" lineAnchorClipping="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" lineAnchorType="0" allowDegraded="0" dist="0" geometryGeneratorEnabled="0" centroidInside="0" maximumDistance="0" geometryGenerator="" maximumDistanceUnit="MM" yOffset="0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" lineAnchorTextPoint="FollowPlacement" maxCurvedCharAngleOut="-25" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" maxCurvedCharAngleIn="25" quadOffset="4" fitInPolygonOnly="0" layerType="PolygonGeometry" prioritization="PreferCloser" priority="5" overrunDistanceUnit="MM" polygonPlacementFlags="2"/>
+      <rendering fontMinPixelSize="3" scaleMax="0" minFeatureSize="0" upsidedownLabels="0" fontMaxPixelSize="10000" fontLimitPixelSize="0" obstacleType="1" labelPerPart="0" drawLabels="1" obstacleFactor="1" scaleVisibility="0" scaleMin="0" obstacle="1" maxNumLabels="2000" limitNumLabels="0" mergeLines="0" zIndex="0" unplacedVisibility="0"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option name="properties"/>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+          <Option type="int" value="0" name="blendMode"/>
+          <Option type="Map" name="ddProperties">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+          <Option type="bool" value="false" name="drawToAllParts"/>
+          <Option type="QString" value="0" name="enabled"/>
+          <Option type="QString" value="point_on_exterior" name="labelAnchorPoint"/>
+          <Option type="QString" value="&lt;symbol type=&quot;line&quot; name=&quot;symbol&quot; frame_rate=&quot;10&quot; is_animated=&quot;0&quot; force_rhr=&quot;0&quot; alpha=&quot;1&quot; clip_to_extent=&quot;1&quot;>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;layer id=&quot;{7f395ec5-2e03-40ab-a071-df4a4fd4db6e}&quot; pass=&quot;0&quot; locked=&quot;0&quot; enabled=&quot;1&quot; class=&quot;SimpleLine&quot;>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;align_dash_pattern&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;square&quot; name=&quot;capstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;5;2&quot; name=&quot;customdash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;customdash_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;customdash_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;dash_pattern_offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;dash_pattern_offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;dash_pattern_offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;draw_inside_polygon&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;bevel&quot; name=&quot;joinstyle&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;60,60,60,255,rgb:0.23529411764705882,0.23529411764705882,0.23529411764705882,1&quot; name=&quot;line_color&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;solid&quot; name=&quot;line_style&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0.3&quot; name=&quot;line_width&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;line_width_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;offset&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;offset_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;offset_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;ring_filter&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_end&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_end_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_end_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;trim_distance_start&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;trim_distance_start_map_unit_scale&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;MM&quot; name=&quot;trim_distance_start_unit&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;tweak_dash_pattern_on_corners&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;0&quot; name=&quot;use_custom_dash&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;3x:0,0,0,0,0,0&quot; name=&quot;width_map_unit_scale&quot;/>&lt;/Option>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+          <Option type="double" value="0" name="minLength"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+          <Option type="QString" value="MM" name="minLengthUnit"/>
+          <Option type="double" value="0" name="offsetFromAnchor"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+          <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+          <Option type="double" value="0" name="offsetFromLabel"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+          <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <fieldConfiguration>
+    <field name="fid" configurationFlags="NoFlag">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="commento" configurationFlags="NoFlag">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="proc_parz" configurationFlags="NoFlag">
+      <editWidget type="ValueMap">
+        <config>
+          <Option type="Map">
+            <Option type="List" name="map">
+              <Option type="Map">
+                <Option type="QString" value="1110" name="Alluvionamento corso d'acqua minore"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1120" name="Alluvionamento corso d'acqua principale"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2002" name="Colata detritica di versante"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1200" name="Flusso detrito"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="1400" name="Ruscellamento superficiale"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="2001" name="Scivolamento spontaneo"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="3000" name="Caduta sassi o blocchi"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="4100" name="Valanga radente"/>
+              </Option>
+              <Option type="Map">
+                <Option type="QString" value="4200" name="Valanga polverosa"/>
+              </Option>
+            </Option>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="fonte_proc" configurationFlags="NoFlag">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="invalid" name="Description"/>
+            <Option type="invalid" name="FilterExpression"/>
+            <Option type="QString" value="fonte_proc" name="Key"/>
+            <Option type="QString" value="Zone_instabilita_1ed06e0b_ac25_48cb_a1ae_d42c8a2f4097" name="Layer"/>
+            <Option type="QString" value="Zona sorgente (fonte processo)" name="LayerName"/>
+            <Option type="QString" value="ogr" name="LayerProviderName"/>
+            <Option type="QString" value="F:/UPIP/06_StrumentiGis/02_Progetti base/09_Plugin QGIS/01_Test QGIS/Mod.proc.CadutaSassi2024/data_3000_19092023_145610.gpkg|layername=Zone_instabilita" name="LayerSource"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="fonte_proc" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias field="fid" name="" index="0"/>
+    <alias field="commento" name="Nome" index="1"/>
+    <alias field="proc_parz" name="Processo" index="2"/>
+    <alias field="fonte_proc" name="Fonte processo" index="3"/>
+  </aliases>
+  <splitPolicies>
+    <policy field="fid" policy="Duplicate"/>
+    <policy field="commento" policy="Duplicate"/>
+    <policy field="proc_parz" policy="Duplicate"/>
+    <policy field="fonte_proc" policy="Duplicate"/>
+  </splitPolicies>
+  <duplicatePolicies>
+    <policy field="fid" policy="Duplicate"/>
+    <policy field="commento" policy="Duplicate"/>
+    <policy field="proc_parz" policy="Duplicate"/>
+    <policy field="fonte_proc" policy="Duplicate"/>
+  </duplicatePolicies>
+  <defaults>
+    <default field="fid" applyOnUpdate="0" expression=""/>
+    <default field="commento" applyOnUpdate="0" expression=""/>
+    <default field="proc_parz" applyOnUpdate="0" expression="@pzp_process"/>
+    <default field="fonte_proc" applyOnUpdate="0" expression=""/>
+  </defaults>
+  <constraints>
+    <constraint constraints="3" notnull_strength="1" field="fid" exp_strength="0" unique_strength="1"/>
+    <constraint constraints="0" notnull_strength="0" field="commento" exp_strength="0" unique_strength="0"/>
+    <constraint constraints="1" notnull_strength="1" field="proc_parz" exp_strength="0" unique_strength="0"/>
+    <constraint constraints="0" notnull_strength="0" field="fonte_proc" exp_strength="0" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="fid" desc=""/>
+    <constraint exp="" field="commento" desc=""/>
+    <constraint exp="" field="proc_parz" desc=""/>
+    <constraint exp="" field="fonte_proc" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <labelStyle labelColor="" overrideLabelColor="0" overrideLabelFont="0">
+      <labelFont italic="0" bold="0" style="" strikethrough="0" description="Ubuntu Sans,11,-1,5,50,0,0,0,0,0" underline="0"/>
+    </labelStyle>
+    <attributeEditorContainer type="Tab" collapsedExpressionEnabled="0" name="Attributi" showLabel="1" collapsedExpression="" verticalStretch="0" groupBox="0" collapsed="0" columnCount="1" visibilityExpression="" horizontalStretch="0" visibilityExpressionEnabled="0">
+      <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+        <labelFont italic="0" bold="0" style="" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+      </labelStyle>
+      <attributeEditorField name="proc_parz" showLabel="1" verticalStretch="0" horizontalStretch="0" index="2">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont italic="0" bold="0" style="" strikethrough="0" description="Noto Sans,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorField name="commento" showLabel="1" verticalStretch="0" horizontalStretch="0" index="1">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont italic="0" bold="0" style="" strikethrough="0" description="Noto Sans,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+        </labelStyle>
+      </attributeEditorField>
+      <attributeEditorField name="fonte_proc" showLabel="1" verticalStretch="0" horizontalStretch="0" index="3">
+        <labelStyle labelColor="0,0,0,255,rgb:0,0,0,1" overrideLabelColor="0" overrideLabelFont="0">
+          <labelFont italic="0" bold="0" style="" strikethrough="0" description="MS Shell Dlg 2,8.25,-1,5,50,0,0,0,0,0" underline="0"/>
+        </labelStyle>
+      </attributeEditorField>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field name="commento" editable="1"/>
+    <field name="fid" editable="1"/>
+    <field name="fonte_proc" editable="1"/>
+    <field name="proc_parz" editable="0"/>
+  </editable>
+  <labelOnTop>
+    <field name="commento" labelOnTop="0"/>
+    <field name="fid" labelOnTop="0"/>
+    <field name="fonte_proc" labelOnTop="0"/>
+    <field name="proc_parz" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field name="commento" reuseLastValue="0"/>
+    <field name="fid" reuseLastValue="0"/>
+    <field name="fonte_proc" reuseLastValue="0"/>
+    <field name="proc_parz" reuseLastValue="0"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>"commento"</previewExpression>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/pzp/qml/danger_level.qml
+++ b/pzp/qml/danger_level.qml
@@ -864,7 +864,31 @@
           <Option type="Map">
             <Option type="List" name="map">
               <Option type="Map">
+                <Option value="1110" type="QString" name="Alluvionamento corso d'acqua minore"/>
+              </Option>
+              <Option type="Map">
+                <Option value="1120" type="QString" name="Alluvionamento corso d'acqua principale"/>
+              </Option>
+              <Option type="Map">
+                <Option value="1200" type="QString" name="Flusso detrito"/>
+              </Option>
+              <Option type="Map">
+                <Option value="1400" type="QString" name="Ruscellamento superficiale"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2001" type="QString" name="Scivolamento spontaneo"/>
+              </Option>
+              <Option type="Map">
+                <Option value="2002" type="QString" name="Colata detritica di versante"/>
+              </Option>
+              <Option type="Map">
                 <Option value="3000" type="QString" name="Caduta sassi o blocchi"/>
+              </Option>
+              <Option type="Map">
+                <Option value="4100" type="QString" name="Valanga radente"/>
+              </Option>
+              <Option type="Map">
+                <Option value="4200" type="QString" name="Valanga polverosa"/>
               </Option>
             </Option>
           </Option>

--- a/pzp/ui/add_process.ui
+++ b/pzp/ui/add_process.ui
@@ -23,16 +23,9 @@ Verrà creato un gruppo di layer per quel processo nel progetto corrente.</strin
     </widget>
    </item>
    <item>
-    <layout class="QFormLayout" name="formLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Directory dati</string>
-       </property>
-      </widget>
-     </item>
+    <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="1">
-      <widget class="QgsFileWidget" name="file_widget" native="true"/>
+      <widget class="QLineEdit" name="directory_lineEdit"/>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_3">
@@ -41,7 +34,21 @@ Verrà creato un gruppo di layer per quel processo nel progetto corrente.</strin
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Directory dati</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QToolButton" name="directory_toolButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1" colspan="2">
       <widget class="QComboBox" name="process_cbox"/>
      </item>
     </layout>
@@ -61,13 +68,6 @@ Verrà creato un gruppo di layer per quel processo nel progetto corrente.</strin
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>QgsFileWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsfilewidget.h</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/pzp/ui/add_process.ui
+++ b/pzp/ui/add_process.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>427</width>
+    <width>453</width>
     <height>184</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Aggiungi processo</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -32,14 +32,7 @@ Verrà creato un gruppo di layer per quel processo nel progetto corrente.</strin
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QgsFileWidget" name="file_widget">
-       <property name="storageMode">
-        <enum>QgsFileWidget::GetDirectory</enum>
-       </property>
-       <property name="options">
-        <set>QFileDialog::ShowDirsOnly</set>
-       </property>
-      </widget>
+      <widget class="QgsFileWidget" name="file_widget" native="true"/>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_3">

--- a/pzp/ui/add_process.ui
+++ b/pzp/ui/add_process.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>453</width>
+    <width>427</width>
     <height>184</height>
    </rect>
   </property>
@@ -23,9 +23,23 @@ Verrà creato un gruppo di layer per quel processo nel progetto corrente.</strin
     </widget>
    </item>
    <item>
-    <layout class="QGridLayout" name="gridLayout">
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Directory dati</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
-      <widget class="QLineEdit" name="directory_lineEdit"/>
+      <widget class="QgsFileWidget" name="file_widget">
+       <property name="storageMode">
+        <enum>QgsFileWidget::GetDirectory</enum>
+       </property>
+       <property name="options">
+        <set>QFileDialog::ShowDirsOnly</set>
+       </property>
+      </widget>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_3">
@@ -34,21 +48,7 @@ Verrà creato un gruppo di layer per quel processo nel progetto corrente.</strin
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Directory dati</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QToolButton" name="directory_toolButton">
-       <property name="text">
-        <string>...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1" colspan="2">
+     <item row="1" column="1">
       <widget class="QComboBox" name="process_cbox"/>
      </item>
     </layout>
@@ -68,6 +68,13 @@ Verrà creato un gruppo di layer per quel processo nel progetto corrente.</strin
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/tests/test_add_process.py
+++ b/tests/test_add_process.py
@@ -5,7 +5,7 @@ from qgis.core import QgsExpressionContextUtils, QgsLayerTreeLayer, QgsProject
 from qgis.testing import start_app
 from qgis.testing.mocked import get_iface
 
-from pzp.add_process import add_process
+from pzp.add_process import AddProcessDialog
 
 start_app()
 
@@ -58,7 +58,7 @@ def test_add_process_caduta_sassi(plugin_instance, gpkg_dir_path, project):
     print(" [INFO] Validating add process Caduta sassi...")
     process_type = 3000
 
-    add_process(process_type, gpkg_dir_path)
+    AddProcessDialog.add_process(process_type, gpkg_dir_path)
 
     # Test expected root group
     assert len(project.layerTreeRoot().children()) == 1  # Root group


### PR DESCRIPTION
Thus we need 2 different qml for Area depending on process type

Additionally:
- Pericolo layer QML was missing some definitions
- Fix inconsitent add process dialog asking for directory but requiring gpkg with the browse button